### PR TITLE
test(query-string): add remaining unit tests in queryString.test

### DIFF
--- a/packages/core/src/http/queryString.ts
+++ b/packages/core/src/http/queryString.ts
@@ -202,11 +202,9 @@ export function urlEncodeObject(
  * @param params List of key-value pairs to serialize
  * @return The result of serialization
  */
-export function urlEncodeKeyValuePairs(
-  params: FormKeyValuePairList | undefined
-): string {
+export function urlEncodeKeyValuePairs(params: FormKeyValuePairList): string {
   const encode = encodeURIComponent;
-  return (params || [])
+  return params
     .map((p) => `${encode(p.key)}=${encode(p.value.toString())}`)
     .join('&');
 }

--- a/packages/core/test/http/queryString.test.ts
+++ b/packages/core/test/http/queryString.test.ts
@@ -1,5 +1,6 @@
 import { FileWrapper, isFileWrapper } from '../../src/fileWrapper';
 import fs from 'fs';
+import path from 'path';
 import {
   urlEncodeObject,
   ArrayPrefixFunction,
@@ -14,6 +15,23 @@ import {
   formDataEncodeObject,
 } from '../../src/http/queryString';
 
+const dependent1 = {
+  name: 'rehan',
+  field: 'front-end',
+};
+Object.setPrototypeOf(dependent1, { lastName: 'adnan' });
+
+const dependent2 = {
+  name: 'Gill',
+  field: 'back-end',
+};
+
+const employee = {
+  age: 15,
+  dependents: [dependent1, dependent2],
+  dependentIDs: [1, 2, 3],
+};
+
 describe('test query encoding', () => {
   test.each([
     [
@@ -24,16 +42,9 @@ describe('test query encoding', () => {
     ],
     [
       'test simple object indexed prefix format',
-      {
-        age: 15,
-        dependents: [
-          { name: 'rehan', field: 'front-end' },
-          { name: 'Gill', field: 'back-end' },
-          [1, 2, 3],
-        ],
-      },
+      employee,
       indexedPrefix,
-      `age=15&dependents[0][name]=rehan&dependents[0][field]=front-end&dependents[1][name]=Gill&dependents[1][field]=back-end&dependents[2][0]=1&dependents[2][1]=2&dependents[2][2]=3`,
+      `age=15&dependents[0][name]=rehan&dependents[0][field]=front-end&dependents[1][name]=Gill&dependents[1][field]=back-end&dependentIDs[0]=1&dependentIDs[1]=2&dependentIDs[2]=3`,
     ],
     [
       'test complex indexed prefix format',
@@ -653,11 +664,24 @@ describe('test query encoding', () => {
       `complexType[key1][numberListType]=555|666|777&complexType[key1][numberMapType][num1]=1&complexType[key1][numberMapType][num3]=2&complexType[key1][numberMapType][num2]=3&complexType[key1][innerComplexType][stringType]=MyString1&complexType[key1][innerComplexType][booleanType]=true&complexType[key1][innerComplexType][dateTimeType]=1994-11-06T08:49:37Z&complexType[key1][innerComplexType][dateType]=1994-02-13&complexType[key1][innerComplexType][uuidType]=a5e48529-745b-4dfb-aac0-a7d844debd8b&complexType[key1][innerComplexType][longType]=500000000&complexType[key1][innerComplexType][precisionType]=5.43&complexType[key1][innerComplexType][objectType][long2]=1000000000&complexType[key1][innerComplexType][objectType][long1]=500000000&complexType[key1][innerComplexType][stringListType]=Item1|Item2&complexType[key1][innerComplexListType][0][stringType]=MyString1&complexType[key1][innerComplexListType][0][booleanType]=true&complexType[key1][innerComplexListType][0][dateTimeType]=1994-11-06T08:49:37Z&complexType[key1][innerComplexListType][0][dateType]=1994-02-13&complexType[key1][innerComplexListType][0][uuidType]=a5e48529-745b-4dfb-aac0-a7d844debd8b&complexType[key1][innerComplexListType][0][longType]=500000000&complexType[key1][innerComplexListType][0][precisionType]=5.43&complexType[key1][innerComplexListType][0][objectType][long2]=1000000000&complexType[key1][innerComplexListType][0][objectType][long1]=500000000&complexType[key1][innerComplexListType][0][stringListType]=Item1|Item2&complexType[key1][innerComplexListType][1][stringType]=MyString2&complexType[key1][innerComplexListType][1][booleanType]=false&complexType[key1][innerComplexListType][1][dateTimeType]=1994-11-06T08:49:37Z&complexType[key1][innerComplexListType][1][dateType]=1994-02-12&complexType[key1][innerComplexListType][1][uuidType]=b46ba2d3-b4ac-4b40-ae62-6326e88c89a6&complexType[key1][innerComplexListType][1][longType]=1000000000&complexType[key1][innerComplexListType][1][precisionType]=5.43&complexType[key1][innerComplexListType][1][objectType][bool1]=true&complexType[key1][innerComplexListType][1][objectType][bool2]=false&complexType[key1][innerComplexListType][1][stringListType]=Item1|Item2&complexType[key2][numberListType]=555|666|777&complexType[key2][numberMapType][num1]=1&complexType[key2][numberMapType][num3]=2&complexType[key2][numberMapType][num2]=3&complexType[key2][innerComplexType][stringType]=MyString1&complexType[key2][innerComplexType][booleanType]=true&complexType[key2][innerComplexType][dateTimeType]=1994-11-06T08:49:37Z&complexType[key2][innerComplexType][dateType]=1994-02-13&complexType[key2][innerComplexType][uuidType]=a5e48529-745b-4dfb-aac0-a7d844debd8b&complexType[key2][innerComplexType][longType]=500000000&complexType[key2][innerComplexType][precisionType]=5.43&complexType[key2][innerComplexType][objectType][long2]=1000000000&complexType[key2][innerComplexType][objectType][long1]=500000000&complexType[key2][innerComplexType][stringListType]=Item1|Item2&complexType[key2][innerComplexListType][0][stringType]=MyString1&complexType[key2][innerComplexListType][0][booleanType]=true&complexType[key2][innerComplexListType][0][dateTimeType]=1994-11-06T08:49:37Z&complexType[key2][innerComplexListType][0][dateType]=1994-02-13&complexType[key2][innerComplexListType][0][uuidType]=a5e48529-745b-4dfb-aac0-a7d844debd8b&complexType[key2][innerComplexListType][0][longType]=500000000&complexType[key2][innerComplexListType][0][precisionType]=5.43&complexType[key2][innerComplexListType][0][objectType][long2]=1000000000&complexType[key2][innerComplexListType][0][objectType][long1]=500000000&complexType[key2][innerComplexListType][0][stringListType]=Item1|Item2&complexType[key2][innerComplexListType][1][stringType]=MyString2&complexType[key2][innerComplexListType][1][booleanType]=false&complexType[key2][innerComplexListType][1][dateTimeType]=1994-11-06T08:49:37Z&complexType[key2][innerComplexListType][1][dateType]=1994-02-12&complexType[key2][innerComplexListType][1][uuidType]=b46ba2d3-b4ac-4b40-ae62-6326e88c89a6&complexType[key2][innerComplexListType][1][longType]=1000000000&complexType[key2][innerComplexListType][1][precisionType]=5.43&complexType[key2][innerComplexListType][1][objectType][bool1]=true&complexType[key2][innerComplexListType][1][objectType][bool2]=false&complexType[key2][innerComplexListType][1][stringListType]=Item1|Item2`,
     ],
     [
-      'test null object with default array prefix',
-      { params: null },
+      'test object of null parameters with default array prefix',
+      { param1: null, param2: undefined },
       indexedPrefix,
-      ``,
+      '',
     ],
+    [
+      'test object of empty parameters with default array prefix',
+      { params: {} },
+      indexedPrefix,
+      '',
+    ],
+    [
+      'test object of symbol type parameters with default array prefix',
+      { params: Symbol('test-value') },
+      indexedPrefix,
+      '',
+    ],
+    ['test empty object with default array prefix', {}, indexedPrefix, ''],
   ])(
     '%s',
     (
@@ -679,7 +703,11 @@ describe('test file wrapper filter', () => {
       [
         {
           key: 'file-param',
-          value: new FileWrapper(fs.createReadStream('dummy_file')),
+          value: new FileWrapper(
+            fs.createReadStream(
+              path.join(__dirname, '/packages/core/test/dummy_file.txt')
+            )
+          ),
         },
         { key: 'string-param', value: 'string' },
       ],
@@ -702,7 +730,13 @@ describe('test file wrapper form encoding', () => {
   test.each([
     [
       'test file wrapper indexed prefix format',
-      { param: new FileWrapper(fs.createReadStream('dummy_file')) },
+      {
+        param: new FileWrapper(
+          fs.createReadStream(
+            path.join(__dirname, '/packages/core/test/dummy_file.txt')
+          )
+        ),
+      },
     ],
   ])('%s', (_: string, params: Record<string, unknown>) => {
     const result = formDataEncodeObject(params);


### PR DESCRIPTION
Add test for **filterFileWrapperFromKeyValuePairs** function
Add test for **FileWrapper** object in **formDataEncodeObject** function
![image](https://user-images.githubusercontent.com/80243792/198245440-4fc4b0dd-3df5-49ce-a0bb-50a1017522a9.png)

![image](https://user-images.githubusercontent.com/80243792/198244345-e0d75724-521e-4393-890b-6e780743e943.png)
Note: Jest shows branch coverage of 152-209 is missing but its actually being covered in the simple and complex type tests
closes #59