### PR TITLE
fix(typescript): bumping package version from 0.9.0 to 0.9.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
     "packages/*"
   ],
 
-  "version": "0.9.0"
+  "version": "0.9.1"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apimatic/core",
   "author": "APIMatic Ltd.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "sideEffects": false,
   "main": "lib/index.js",


### PR DESCRIPTION
The released es modules of core package were not building correctly and causing runtime errors and warnings. Apparently the issue was because of [rollup ](https://www.npmjs.com/package/rollup) release

Close #93 