### PR TITLE
Implements multiple auth provider.

### DIFF
--- a/packages/authentication-adapters/package.json
+++ b/packages/authentication-adapters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apimatic/authentication-adapters",
   "author": "APIMatic Ltd.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "MIT",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/authentication-adapters/src/compositeAuthenticationAdapter.ts
+++ b/packages/authentication-adapters/src/compositeAuthenticationAdapter.ts
@@ -103,7 +103,7 @@ export function compositeAuthenticationProvider<
     // error.
     if (!matchingAuthCombination) {
       throw new Error(
-        'Required authentication credentials for this API call not provided.'
+        'Required authentication credentials for this API call are not provided or all provided auth combinations are disabled'
       );
     }
 
@@ -128,8 +128,10 @@ function findMatchingAuth<T extends string>(
   >,
   providerConfig: CompositeAuthProviderConfig<T>
 ) {
-  return securityRequirements.find((andRequirements) =>
-    Object.entries(andRequirements).every((entry) => entry[0] in providerConfig)
+  return securityRequirements.find(
+    (andRequirements) =>
+      Object.keys(andRequirements).every((key) => key in providerConfig) &&
+      Object.values(andRequirements).every((value) => value)
   );
 }
 

--- a/packages/authentication-adapters/src/compositeAuthenticationAdapter.ts
+++ b/packages/authentication-adapters/src/compositeAuthenticationAdapter.ts
@@ -142,8 +142,13 @@ function getHttpInterceptorsForAuths<T extends string>(
   matchingRequirements: Partial<Record<T, unknown>>,
   providerConfig: CompositeAuthProviderConfig<T>
 ): Array<HttpInterceptorInterface<RequestOptions | undefined>> {
-  return Object.entries(matchingRequirements).map((entry) =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (providerConfig as any)[entry[0]](entry[1])
+  return Object.entries(matchingRequirements).map(
+    ([authProvider, authParam]) => {
+      if (providerConfig[authProvider] !== undefined) {
+        return providerConfig[authProvider](authParam);
+      } else {
+        return passThroughInterceptor;
+      }
+    }
   );
 }

--- a/packages/authentication-adapters/src/compositeAuthenticationAdapter.ts
+++ b/packages/authentication-adapters/src/compositeAuthenticationAdapter.ts
@@ -130,8 +130,9 @@ function findMatchingAuth<T extends string>(
 ) {
   return securityRequirements.find(
     (andRequirements) =>
-      Object.keys(andRequirements).every((key) => key in providerConfig) &&
-      Object.values(andRequirements).every((value) => value)
+      Object.keys(andRequirements).every(
+        (key) => key in providerConfig && providerConfig[key]
+      ) && Object.values(andRequirements).every((value) => value)
   );
 }
 

--- a/packages/authentication-adapters/src/compositeAuthenticationAdapter.ts
+++ b/packages/authentication-adapters/src/compositeAuthenticationAdapter.ts
@@ -1,0 +1,147 @@
+import {
+  AuthenticatorInterface,
+  HttpInterceptorInterface,
+  RequestOptions,
+  combineHttpInterceptors,
+  passThroughInterceptor,
+} from '@apimatic/core-interfaces';
+
+/**
+ * Composite auth provider configuration
+ */
+export type CompositeAuthProviderConfig<T extends string> = Partial<
+  Record<
+    T,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    AuthenticatorInterface<any>
+  >
+>;
+
+/**
+ * Security requirements defined by an endpoint
+ */
+export type CompositeAuthSecurityRequirements<
+  T extends string,
+  D extends CompositeAuthProviderConfig<T>
+> = Array<
+  Partial<
+    {
+      [P in T]: D[P] extends undefined | AuthenticatorInterface<infer X>
+        ? X
+        : never;
+    }
+  >
+>;
+
+/**
+ * Auth param type for composite auth.
+ */
+export type CompositeAuthParams<
+  T extends string,
+  D extends CompositeAuthProviderConfig<T>
+> = CompositeAuthSecurityRequirements<T, D> | false;
+
+/**
+ * Create a Composite Authentication provider instance using the given configuration.
+ *
+ * "Composite Authentication Provider" provides authentication by combining one
+ * or more existing auth schemes. Auths can be combined by AND clause. Multiple
+ * AND clauses can be combined using OR clause.
+ *
+ * The compositeAuthProvider instance is created by passing it a map of all the
+ * available authProvider instances. This map is called the
+ * CompositeAuthProviderConfig. For example:
+ *
+ * ```ts
+ * const compositeAuthProviderConfig = {
+ *   basicAuth: basicAuthenticationProvider(...),
+ *   accessToken: accessTokenAuthenticationProvider(...)
+ * };
+ *
+ * const myAuthProvider = compositeAuthProvider(compositeAuthProviderConfig);
+ * ```
+ *
+ * The compositeAuthProvider instance returned adhere to the
+ * AuthenticatorInterface<Params>. This allows it to be used with the
+ * RequestBuilder to authenticate endpoint calls. Endpoints can apply the auth
+ * by passing their "Security Requirements" to the authenticate method like
+ * this:
+ *
+ * ```ts
+ *  const req = this.createRequest('GET', '/auth/basic');
+ *  req.authenticate([{ basicAuth: true }, { accessToken: true }]);
+ *  return req.callAsText(requestOptions);
+ * ```
+ *
+ * Here, `authenticate()` method accepts a type of "Array of Map". The array
+ * denotes auths combined by OR and the map denotes auths combined by AND. This
+ * is similar to how Security Requirements are defined in OpenAPI definitions.
+ *
+ * If the compositeAuthProviderConfig does not satisfy the security requirements
+ * defined by the endpoint, then an exception is thrown.
+ */
+export function compositeAuthenticationProvider<
+  T extends string,
+  D extends CompositeAuthProviderConfig<T>
+>(
+  providerConfig: CompositeAuthProviderConfig<T>
+): AuthenticatorInterface<CompositeAuthParams<T, D>> {
+  return (securityRequirements) => {
+    // If auth param is false or an empty list, skip authentication.
+    if (!securityRequirements || securityRequirements.length === 0) {
+      return passThroughInterceptor;
+    }
+
+    // Find an auth combination in the list of optional combinations that can be
+    // applied given the current auth configuration.
+    const matchingAuthCombination = findMatchingAuth(
+      securityRequirements,
+      providerConfig
+    );
+
+    // If no auth combination satisfies the security requirements, raise an
+    // error.
+    if (!matchingAuthCombination) {
+      throw new Error(
+        'Required authentication credentials for this API call not provided.'
+      );
+    }
+
+    // Get interceptors for the selected auth combination.
+    const authInterceptors = getHttpInterceptorsForAuths(
+      matchingAuthCombination,
+      providerConfig
+    );
+
+    return combineHttpInterceptors(authInterceptors);
+  };
+}
+
+/**
+ * Finds the matching AND combination inside the security requirements list that
+ * can be applied given the current provider config.
+ */
+function findMatchingAuth<T extends string>(
+  securityRequirements: CompositeAuthSecurityRequirements<
+    T,
+    CompositeAuthProviderConfig<T>
+  >,
+  providerConfig: CompositeAuthProviderConfig<T>
+) {
+  return securityRequirements.find((andRequirements) =>
+    Object.entries(andRequirements).every((entry) => entry[0] in providerConfig)
+  );
+}
+
+/**
+ * Get HTTP interceptor instances from each auth provider
+ */
+function getHttpInterceptorsForAuths<T extends string>(
+  matchingRequirements: Partial<Record<T, unknown>>,
+  providerConfig: CompositeAuthProviderConfig<T>
+): Array<HttpInterceptorInterface<RequestOptions | undefined>> {
+  return Object.entries(matchingRequirements).map((entry) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (providerConfig as any)[entry[0]](entry[1])
+  );
+}

--- a/packages/authentication-adapters/src/index.ts
+++ b/packages/authentication-adapters/src/index.ts
@@ -3,3 +3,4 @@ export * from './customHeaderAuthenticationAdapter';
 export * from './customQueryAuthenticationAdapter';
 export * from './accessTokenAdapter';
 export * from './noAuthenticationAdapter';
+export * from './compositeAuthenticationAdapter';

--- a/packages/authentication-adapters/test/compositeAuthenticationAdapter.test.ts
+++ b/packages/authentication-adapters/test/compositeAuthenticationAdapter.test.ts
@@ -1,0 +1,265 @@
+import { accessTokenAuthenticationProvider } from '../src/accessTokenAdapter';
+import { basicAuthenticationProvider } from '../src/basicAuthenticationAdapter';
+import { compositeAuthenticationProvider } from '../src/compositeAuthenticationAdapter';
+import { customQueryAuthenticationProvider } from '../src/customQueryAuthenticationAdapter';
+import { customHeaderAuthenticationProvider } from '../src/customHeaderAuthenticationAdapter';
+import { callHttpInterceptors } from '../../core/src/http/httpInterceptor';
+import { HttpRequest, HttpResponse } from '@apimatic/core-interfaces';
+
+describe('test composite Authentication Adapter', () => {
+  const config = {
+    timeout: 60000,
+    environment: 'Production',
+    customUrl: 'https://connect.product.com',
+    accessTokenCredentials: {
+      accessToken: '0b79bab50daca910bmmmd4f1a2b675d606555e222',
+    },
+    basicAuthCredentials: {
+      username: 'Maryam',
+      password: '123456',
+    },
+    apiKeyCredentials: {
+      token: 'asdqwaxr2gSdhasWSDbdAgdA623ffghhhde7Adysi23',
+      apiKey: 'api-key',
+    },
+    apiHeaderCredentials: {
+      token: 'Qaws2W233tuyess4T56G6Vref2',
+      apiKey: 'api-key',
+    },
+    oAuthBearerTokenCredentials: {
+      accessToken: '0b79bab50daca54cchg12k000d4f1a2b675d604257e42',
+    },
+  };
+
+  const authConfig = {
+    accessToken:
+      config.accessTokenCredentials &&
+      accessTokenAuthenticationProvider(config.accessTokenCredentials),
+    basicAuth:
+      config.basicAuthCredentials &&
+      basicAuthenticationProvider(
+        config.basicAuthCredentials.username,
+        config.basicAuthCredentials.password
+      ),
+    apiKey:
+      config.apiKeyCredentials &&
+      customQueryAuthenticationProvider(config.apiKeyCredentials),
+    apiHeader:
+      config.apiHeaderCredentials &&
+      customHeaderAuthenticationProvider(config.apiHeaderCredentials),
+    oAuthBearerToken:
+      config.oAuthBearerTokenCredentials &&
+      accessTokenAuthenticationProvider(config.oAuthBearerTokenCredentials),
+  };
+
+  const response: HttpResponse = {
+    statusCode: 200,
+    body: 'testBody',
+    headers: { 'test-header': 'test-value' },
+  };
+
+  it('should test OR scheme with enabled accessToken and enabled basicAuth', async () => {
+    const request: HttpRequest = {
+      method: 'GET',
+      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+    };
+    const securityRequirements = [{ accessToken: true }, { basicAuth: true }];
+    const provider = compositeAuthenticationProvider(authConfig);
+    const interceptor = [provider(securityRequirements)];
+    const client = async (req) => {
+      return { request: req, response };
+    };
+    const executor = callHttpInterceptors(interceptor, client);
+    const context = await executor(request, undefined);
+    expect(context.request.headers).toEqual({
+      authorization: 'Bearer 0b79bab50daca910bmmmd4f1a2b675d606555e222',
+    });
+    expect(context.request.auth).toEqual(undefined);
+  });
+
+  it('should test OR scheme with enabled accessToken and disabled basicAuth', async () => {
+    const request: HttpRequest = {
+      method: 'GET',
+      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+    };
+    const securityRequirements = [{ accessToken: true }, { basicAuth: false }];
+    const provider = compositeAuthenticationProvider(authConfig);
+    const interceptor = [provider(securityRequirements)];
+    const client = async (req) => {
+      return { request: req, response };
+    };
+    const executor = callHttpInterceptors(interceptor, client);
+    const context = await executor(request, undefined);
+    expect(context.request.headers).toEqual({
+      authorization: 'Bearer 0b79bab50daca910bmmmd4f1a2b675d606555e222',
+    });
+    expect(context.request.auth).toEqual(undefined);
+  });
+
+  it('should test OR scheme with disabled accessToken and enabled basicAuth', async () => {
+    const request: HttpRequest = {
+      method: 'GET',
+      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+    };
+    const securityRequirements = [{ accessToken: false }, { basicAuth: true }];
+    const provider = compositeAuthenticationProvider(authConfig);
+    const interceptor = [provider(securityRequirements)];
+    const client = async (req) => {
+      return { request: req, response };
+    };
+    const executor = callHttpInterceptors(interceptor, client);
+    const context = await executor(request, undefined);
+    expect(context.request.headers).toEqual(undefined);
+    expect(context.request.auth).toEqual({
+      username: 'Maryam',
+      password: '123456',
+    });
+  });
+
+  it('should test OR scheme with disabled accessToken and disabled basicAuth', async () => {
+    try {
+      const request: HttpRequest = {
+        method: 'GET',
+        url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+      };
+      const securityRequirements = [
+        { accessToken: false },
+        { basicAuth: false },
+      ];
+      const provider = compositeAuthenticationProvider(authConfig);
+      const interceptor = [provider(securityRequirements)];
+      const client = async (req) => {
+        return { request: req, response };
+      };
+      const executor = callHttpInterceptors(interceptor, client);
+      const context = await executor(request, undefined);
+      expect(context.request.headers).toEqual(undefined);
+      expect(context.request.auth).toEqual(undefined);
+    } catch (error) {
+      expect(error.message).toEqual(
+        'Required authentication credentials for this API call are not provided or all provided auth combinations are disabled'
+      );
+    }
+  });
+
+  it('should test AND scheme with disabled accessToken and enabled basicAuth', async () => {
+    try {
+      const request: HttpRequest = {
+        method: 'GET',
+        url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+      };
+      const securityRequirements = [{ accessToken: false, basicAuth: true }];
+      const provider = compositeAuthenticationProvider(authConfig);
+      const interceptor = [provider(securityRequirements)];
+      const client = async (req) => {
+        return { request: req, response };
+      };
+      const executor = callHttpInterceptors(interceptor, client);
+      const context = await executor(request, undefined);
+      expect(context.request.auth).toEqual({
+        username: 'Maryam',
+        password: '123456',
+      });
+    } catch (error) {
+      expect(error.message).toEqual(
+        'Required authentication credentials for this API call are not provided or all provided auth combinations are disabled'
+      );
+    }
+  });
+
+  it('should test AND scheme with enabled accessToken and enabled basicAuth', async () => {
+    const request: HttpRequest = {
+      method: 'GET',
+      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+    };
+    const securityRequirements = [{ accessToken: true, basicAuth: true }];
+    const provider = compositeAuthenticationProvider(authConfig);
+    const interceptor = [provider(securityRequirements)];
+    const client = async (req) => {
+      return { request: req, response };
+    };
+    const executor = callHttpInterceptors(interceptor, client);
+    const context = await executor(request, undefined);
+    expect(context.request.headers).toEqual({
+      authorization: 'Bearer 0b79bab50daca910bmmmd4f1a2b675d606555e222',
+    });
+    expect(context.request.auth).toEqual({
+      username: 'Maryam',
+      password: '123456',
+    });
+  });
+
+  it('should test AND scheme with enabled accessToken and disabled basicAuth', async () => {
+    try {
+      const request: HttpRequest = {
+        method: 'GET',
+        url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+      };
+      const securityRequirements = [{ accessToken: true, basicAuth: false }];
+      const provider = compositeAuthenticationProvider(authConfig);
+      const interceptor = [provider(securityRequirements)];
+      const client = async (req) => {
+        return { request: req, response };
+      };
+      const executor = callHttpInterceptors(interceptor, client);
+      const context = await executor(request, undefined);
+      expect(context.request.headers).toEqual({
+        authorization: 'Bearer 0b79bab50daca910bmmmd4f1a2b675d606555e222',
+      });
+    } catch (error) {
+      expect(error.message).toEqual(
+        'Required authentication credentials for this API call are not provided or all provided auth combinations are disabled'
+      );
+    }
+  });
+
+  it('should test scheme combination with enabled apiKey, basicAuth, apiHeader or enabled oAuthBearerToken', async () => {
+    const request: HttpRequest = {
+      method: 'GET',
+      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+    };
+    const securityRequirements = [
+      { apiKey: true, basicAuth: true, apiHeader: true },
+      { oAuthBearerToken: true },
+    ];
+    const provider = compositeAuthenticationProvider(authConfig);
+    const interceptor = [provider(securityRequirements)];
+    const client = async (req) => {
+      return { request: req, response };
+    };
+    const executor = callHttpInterceptors(interceptor, client);
+    const context = await executor(request, undefined);
+    expect(context.request.headers).toEqual({
+      apiKey: 'api-key',
+      token: 'Qaws2W233tuyess4T56G6Vref2',
+    });
+    expect(context.request.auth).toEqual({
+      username: 'Maryam',
+      password: '123456',
+    });
+    expect(context.request.url).toEqual(
+      'http://apimatic.hopto.org:3000/test/requestBuilder?token=asdqwaxr2gSdhasWSDbdAgdA623ffghhhde7Adysi23&apiKey=api-key'
+    );
+  });
+
+  it('should test scheme combination with disabled apiKey, basicAuth, apiHeader or enabled oAuthBearerToken', async () => {
+    const request: HttpRequest = {
+      method: 'GET',
+      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+    };
+    const securityRequirements = [
+      { apiKey: true, basicAuth: false, apiHeader: true },
+      { oAuthBearerToken: true },
+    ];
+    const provider = compositeAuthenticationProvider(authConfig);
+    const interceptor = [provider(securityRequirements)];
+    const client = async (req) => {
+      return { request: req, response };
+    };
+    const executor = callHttpInterceptors(interceptor, client);
+    const context = await executor(request, undefined);
+    expect(context.request.headers).toEqual({
+      authorization: 'Bearer 0b79bab50daca54cchg12k000d4f1a2b675d604257e42',
+    });
+  });
+});

--- a/packages/authentication-adapters/test/compositeAuthenticationAdapter.test.ts
+++ b/packages/authentication-adapters/test/compositeAuthenticationAdapter.test.ts
@@ -5,29 +5,207 @@ import { customQueryAuthenticationProvider } from '../src/customQueryAuthenticat
 import { customHeaderAuthenticationProvider } from '../src/customHeaderAuthenticationAdapter';
 import { callHttpInterceptors } from '../../core/src/http/httpInterceptor';
 import { HttpRequest, HttpResponse } from '@apimatic/core-interfaces';
+import { requestAuthenticationProvider } from '../../oauth-adapters/src/oauthAuthenticationAdapter';
+import { OAuthToken } from '../../oauth-adapters/src/oAuthToken';
 
-describe('test composite Authentication Adapter', () => {
-  const config = {
+interface Configuration {
+  basicAuthCredentials?: {
+    username: string;
+    password: string;
+  };
+  accessTokenCredentials?: {
+    accessToken: string;
+  };
+  apiKeyCredentials?: {
+    token: string;
+    apiKey: string;
+  };
+  apiHeaderCredentials?: {
+    token: string;
+    apiKey: string;
+  };
+  oAuthBearerTokenCredentials?: {
+    accessToken: string;
+  };
+  oAuthCCGCredentials?: {
+    oAuthClientId: string;
+    oAuthClientSecret: string;
+    oAuthToken?: OAuthToken;
+    oAuthScopes?: 'read' | 'write';
+  };
+  oAuthACGCredentials?: {
+    oAuthClientId: string;
+    oAuthClientSecret: string;
+    oAuthRedirectUri: string;
+    oAuthToken?: OAuthToken;
+    oAuthScopes?: 'read' | 'write';
+  };
+  timeout: number;
+  environment: 'Production' | 'Testing';
+  customUrl: string;
+}
+
+describe('test composite authentication adapter with false or empty security requirements', () => {
+  const config: Configuration = {
+    timeout: 60000,
+    environment: 'Production',
+    customUrl: 'https://connect.product.com',
+  };
+
+  const authConfig = {
+    apiKey:
+      config.apiKeyCredentials &&
+      customQueryAuthenticationProvider(config.apiKeyCredentials),
+    apiHeader:
+      config.apiHeaderCredentials &&
+      customHeaderAuthenticationProvider(config.apiHeaderCredentials),
+  };
+
+  const response: HttpResponse = {
+    statusCode: 200,
+    body: 'testBody',
+    headers: { 'test-header': 'test-value' },
+  };
+
+  it('should test false security requirements', async () => {
+    const request: HttpRequest = {
+      method: 'GET',
+      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+    };
+    const securityRequirements = false;
+    const provider = compositeAuthenticationProvider(authConfig);
+    const interceptor = [provider(securityRequirements)];
+    const client = async (req) => {
+      return { request: req, response };
+    };
+    const executor = callHttpInterceptors(interceptor, client);
+    const context = await executor(request, undefined);
+    expect(context.request.headers).toEqual(undefined);
+    expect(context.request.url).toEqual(
+      'http://apimatic.hopto.org:3000/test/requestBuilder'
+    );
+  });
+
+  it('should test empty security requirements', async () => {
+    try {
+      const request: HttpRequest = {
+        method: 'GET',
+        url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+      };
+      const securityRequirements = [];
+      const provider = compositeAuthenticationProvider(authConfig);
+      const interceptor = [provider(securityRequirements)];
+      const client = async (req) => {
+        return { request: req, response };
+      };
+      const executor = callHttpInterceptors(interceptor, client);
+      const context = await executor(request, undefined);
+      expect(context.request.headers).toEqual(undefined);
+      expect(context.request.auth).toEqual(undefined);
+    } catch (error) {
+      expect(error.message).toEqual(
+        'Required authentication credentials for this API call are not provided or all provided auth combinations are disabled'
+      );
+    }
+  });
+});
+
+describe('test composite authentication adapter with no credentials object provided', () => {
+  const config: Configuration = {
+    timeout: 60000,
+    environment: 'Production',
+    customUrl: 'https://connect.product.com',
+  };
+
+  const authConfig = {
+    apiKey:
+      config.apiKeyCredentials &&
+      customQueryAuthenticationProvider(config.apiKeyCredentials),
+    apiHeader:
+      config.apiHeaderCredentials &&
+      customHeaderAuthenticationProvider(config.apiHeaderCredentials),
+  };
+
+  const response: HttpResponse = {
+    statusCode: 200,
+    body: 'testBody',
+    headers: { 'test-header': 'test-value' },
+  };
+
+  it('should test OR scheme with enabled custom query and enabled custom header', async () => {
+    const request: HttpRequest = {
+      method: 'GET',
+      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+    };
+    const securityRequirements = [{ apiKey: true }, { apiHeader: true }];
+    const provider = compositeAuthenticationProvider(authConfig);
+    const interceptor = [provider(securityRequirements)];
+    const client = async (req) => {
+      return { request: req, response };
+    };
+    const executor = callHttpInterceptors(interceptor, client);
+    const context = await executor(request, undefined);
+    expect(context.request.headers).toEqual(undefined);
+    expect(context.request.url).toEqual(
+      'http://apimatic.hopto.org:3000/test/requestBuilder'
+    );
+  });
+
+  it('should test OR scheme with disabled accessToken and disabled basicAuth', async () => {
+    try {
+      const request: HttpRequest = {
+        method: 'GET',
+        url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+      };
+      const securityRequirements = [{ apiKey: false }, { apiHeader: false }];
+      const provider = compositeAuthenticationProvider(authConfig);
+      const interceptor = [provider(securityRequirements)];
+      const client = async (req) => {
+        return { request: req, response };
+      };
+      const executor = callHttpInterceptors(interceptor, client);
+      const context = await executor(request, undefined);
+      expect(context.request.headers).toEqual(undefined);
+      expect(context.request.auth).toEqual(undefined);
+    } catch (error) {
+      expect(error.message).toEqual(
+        'Required authentication credentials for this API call are not provided or all provided auth combinations are disabled'
+      );
+    }
+  });
+});
+
+describe('test composite authentication adapter with security requirements combinations and provided authCredentials', () => {
+  const config: Configuration = {
     timeout: 60000,
     environment: 'Production',
     customUrl: 'https://connect.product.com',
     accessTokenCredentials: {
-      accessToken: '0b79bab50daca910bmmmd4f1a2b675d606555e222',
+      accessToken: '0b79bab50dacabmmmd4f1a2b675d606555e222',
     },
     basicAuthCredentials: {
       username: 'Maryam',
       password: '123456',
     },
     apiKeyCredentials: {
-      token: 'asdqwaxr2gSdhasWSDbdAgdA623ffghhhde7Adysi23',
+      token: 'asdqwaxr2gSdhasWSDbdA623ffghhhde7Adysi23',
       apiKey: 'api-key',
     },
     apiHeaderCredentials: {
-      token: 'Qaws2W233tuyess4T56G6Vref2',
+      token: 'Qaws2W233tuyess6G6Vref2',
       apiKey: 'api-key',
     },
     oAuthBearerTokenCredentials: {
-      accessToken: '0b79bab50daca54cchg12k000d4f1a2b675d604257e42',
+      accessToken: '0b79bab50daca54cchk000d4f1a2b675d604257e42',
+    },
+    oAuthCCGCredentials: {
+      oAuthClientId: '23',
+      oAuthClientSecret: 'tQNSqQlXBIwZcY9auoujQ57ckDcoh3t8UPbBRkSF',
+    },
+    oAuthACGCredentials: {
+      oAuthClientId: '24',
+      oAuthClientSecret: 'Y9auoujQ57ckDtQNSqQlXBIwZccoh3t8UPbBRkSF',
+      oAuthRedirectUri: '',
     },
   };
 
@@ -50,6 +228,12 @@ describe('test composite Authentication Adapter', () => {
     oAuthBearerToken:
       config.oAuthBearerTokenCredentials &&
       accessTokenAuthenticationProvider(config.oAuthBearerTokenCredentials),
+    oAuthCCG:
+      config.oAuthCCGCredentials &&
+      requestAuthenticationProvider(config.oAuthCCGCredentials.oAuthToken),
+    oAuthACG:
+      config.oAuthACGCredentials &&
+      requestAuthenticationProvider(config.oAuthACGCredentials.oAuthToken),
   };
 
   const response: HttpResponse = {
@@ -72,7 +256,7 @@ describe('test composite Authentication Adapter', () => {
     const executor = callHttpInterceptors(interceptor, client);
     const context = await executor(request, undefined);
     expect(context.request.headers).toEqual({
-      authorization: 'Bearer 0b79bab50daca910bmmmd4f1a2b675d606555e222',
+      authorization: 'Bearer 0b79bab50dacabmmmd4f1a2b675d606555e222',
     });
     expect(context.request.auth).toEqual(undefined);
   });
@@ -91,7 +275,7 @@ describe('test composite Authentication Adapter', () => {
     const executor = callHttpInterceptors(interceptor, client);
     const context = await executor(request, undefined);
     expect(context.request.headers).toEqual({
-      authorization: 'Bearer 0b79bab50daca910bmmmd4f1a2b675d606555e222',
+      authorization: 'Bearer 0b79bab50dacabmmmd4f1a2b675d606555e222',
     });
     expect(context.request.auth).toEqual(undefined);
   });
@@ -181,7 +365,7 @@ describe('test composite Authentication Adapter', () => {
     const executor = callHttpInterceptors(interceptor, client);
     const context = await executor(request, undefined);
     expect(context.request.headers).toEqual({
-      authorization: 'Bearer 0b79bab50daca910bmmmd4f1a2b675d606555e222',
+      authorization: 'Bearer 0b79bab50dacabmmmd4f1a2b675d606555e222',
     });
     expect(context.request.auth).toEqual({
       username: 'Maryam',
@@ -204,7 +388,7 @@ describe('test composite Authentication Adapter', () => {
       const executor = callHttpInterceptors(interceptor, client);
       const context = await executor(request, undefined);
       expect(context.request.headers).toEqual({
-        authorization: 'Bearer 0b79bab50daca910bmmmd4f1a2b675d606555e222',
+        authorization: 'Bearer 0b79bab50dacabmmmd4f1a2b675d606555e222',
       });
     } catch (error) {
       expect(error.message).toEqual(
@@ -231,14 +415,14 @@ describe('test composite Authentication Adapter', () => {
     const context = await executor(request, undefined);
     expect(context.request.headers).toEqual({
       apiKey: 'api-key',
-      token: 'Qaws2W233tuyess4T56G6Vref2',
+      token: 'Qaws2W233tuyess6G6Vref2',
     });
     expect(context.request.auth).toEqual({
       username: 'Maryam',
       password: '123456',
     });
     expect(context.request.url).toEqual(
-      'http://apimatic.hopto.org:3000/test/requestBuilder?token=asdqwaxr2gSdhasWSDbdAgdA623ffghhhde7Adysi23&apiKey=api-key'
+      'http://apimatic.hopto.org:3000/test/requestBuilder?token=asdqwaxr2gSdhasWSDbdA623ffghhhde7Adysi23&apiKey=api-key'
     );
   });
 
@@ -259,7 +443,68 @@ describe('test composite Authentication Adapter', () => {
     const executor = callHttpInterceptors(interceptor, client);
     const context = await executor(request, undefined);
     expect(context.request.headers).toEqual({
-      authorization: 'Bearer 0b79bab50daca54cchg12k000d4f1a2b675d604257e42',
+      authorization: 'Bearer 0b79bab50daca54cchk000d4f1a2b675d604257e42',
+    });
+  });
+
+  it('should test scheme combination with enabled oAuthACG oAuthCCG with unset access token', async () => {
+    try {
+      const request: HttpRequest = {
+        method: 'GET',
+        url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+      };
+      const securityRequirements = [{ oAuthACG: true, oAuthCCG: true }];
+      const provider = compositeAuthenticationProvider(authConfig);
+      const interceptor = [provider(securityRequirements)];
+      const client = async (req) => {
+        return { request: req, response };
+      };
+      const executor = callHttpInterceptors(interceptor, client);
+      const context = await executor(request, undefined);
+      expect(context.request.headers).toEqual({
+        authorization: 'Bearer 0b79bab50daca54cchk000d4f1a2b675d604257e42',
+      });
+    } catch (error) {
+      expect(error.message).toEqual(
+        'Client is not authorized. An OAuth token is needed to make API calls.'
+      );
+    }
+  });
+
+  it('should test scheme combination with enabled oAuthACG oAuthCCG with set access token', async () => {
+    if (config.oAuthACGCredentials) {
+      config.oAuthACGCredentials.oAuthToken = {
+        accessToken: '1f12495f1a1ad9066b51fb3b4e456aee',
+        tokenType: 'Bearer',
+        expiresIn: BigInt(100000),
+        scope: '[products, orders]',
+        expiry: BigInt(Date.now()),
+      };
+    }
+
+    const auth1Config = {
+      oAuthCCG:
+        config.oAuthCCGCredentials &&
+        requestAuthenticationProvider(config.oAuthCCGCredentials.oAuthToken),
+      oAuthACG:
+        config.oAuthACGCredentials &&
+        requestAuthenticationProvider(config.oAuthACGCredentials.oAuthToken),
+    };
+
+    const request: HttpRequest = {
+      method: 'GET',
+      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+    };
+    const securityRequirements = [{ oAuthACG: true }, { oAuthCCG: true }];
+    const provider = compositeAuthenticationProvider(auth1Config);
+    const interceptor = [provider(securityRequirements)];
+    const client = async (req) => {
+      return { request: req, response };
+    };
+    const executor = callHttpInterceptors(interceptor, client);
+    const context = await executor(request, undefined);
+    expect(context.request.headers).toEqual({
+      authorization: 'Bearer 1f12495f1a1ad9066b51fb3b4e456aee',
     });
   });
 });

--- a/packages/core-interfaces/package.json
+++ b/packages/core-interfaces/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apimatic/core-interfaces",
   "author": "APIMatic Ltd.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "MIT",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/core-interfaces/src/httpInterceptor.ts
+++ b/packages/core-interfaces/src/httpInterceptor.ts
@@ -1,4 +1,4 @@
-import { HttpRequest, RequestOptions } from './httpRequest';
+import { HttpRequest } from './httpRequest';
 import { HttpContext } from './httpContext';
 
 /**
@@ -41,9 +41,9 @@ export function passThroughInterceptor<T>(
 /**
  * Combine multiple HTTP interceptors into one.
  */
-export function combineHttpInterceptors(
-  interceptors: Array<HttpInterceptorInterface<RequestOptions | undefined>>
-): HttpInterceptorInterface<RequestOptions | undefined> {
+export function combineHttpInterceptors<T>(
+  interceptors: Array<HttpInterceptorInterface<T | undefined>>
+): HttpInterceptorInterface<T | undefined> {
   return (firstRequest, firstOptions, next) => {
     for (let index = interceptors.length - 1; index >= 0; index--) {
       const current = interceptors[index];

--- a/packages/core-interfaces/src/httpInterceptor.ts
+++ b/packages/core-interfaces/src/httpInterceptor.ts
@@ -1,4 +1,4 @@
-import { HttpRequest } from './httpRequest';
+import { HttpRequest, RequestOptions } from './httpRequest';
 import { HttpContext } from './httpContext';
 
 /**
@@ -36,4 +36,20 @@ export function passThroughInterceptor<T>(
   next: HttpCallExecutor<T>
 ): Promise<HttpContext> {
   return next(request, requestOptions);
+}
+
+/**
+ * Combine multiple HTTP interceptors into one.
+ */
+export function combineHttpInterceptors(
+  interceptors: Array<HttpInterceptorInterface<RequestOptions | undefined>>
+): HttpInterceptorInterface<RequestOptions | undefined> {
+  return (firstRequest, firstOptions, next) => {
+    for (let index = interceptors.length - 1; index >= 0; index--) {
+      const current = interceptors[index];
+      const last = next;
+      next = (request, options) => current(request, options, last);
+    }
+    return next(firstRequest, firstOptions);
+  };
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apimatic/core",
   "author": "APIMatic Ltd.",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "license": "MIT",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/core/src/http/httpInterceptor.ts
+++ b/packages/core/src/http/httpInterceptor.ts
@@ -1,6 +1,7 @@
 import {
   HttpInterceptorInterface,
   HttpCallExecutor,
+  combineHttpInterceptors,
 } from '@apimatic/core-interfaces';
 /**
  * Calls HTTP interceptor chain
@@ -12,11 +13,6 @@ export function callHttpInterceptors<T>(
   interceptors: Array<HttpInterceptorInterface<T>>,
   client: HttpCallExecutor<T>
 ): HttpCallExecutor<T> {
-  let next = client;
-  for (let index = interceptors.length - 1; index >= 0; index--) {
-    const current = interceptors[index];
-    const last = next;
-    next = (request, options) => current(request, options, last);
-  }
-  return next;
+  return (request, options) =>
+    combineHttpInterceptors(interceptors)(request, options, client);
 }


### PR DESCRIPTION
## TODO

Closes #136 
## How does Core library implement multiple auth (without breaking changes)?

"Composite Authentication Provider" provides authentication by combining one
or more existing auth schemes. Auths can be combined by AND clause. Multiple
AND clauses can be combined using OR clause.

The compositeAuthProvider instance is created by passing it a map of all the
available authProvider instances. This map is called the
CompositeAuthProviderConfig. For example:

```ts
const compositeAuthProviderConfig = {
  basicAuth: basicAuthenticationProvider(...),
  accessToken: accessTokenAuthenticationProvider(...)
};

const myAuthProvider = compositeAuthProvider(compositeAuthProviderConfig);
```

The compositeAuthProvider instance returned adhere to the
AuthenticatorInterface<Params>. This allows it to be used with the
RequestBuilder to authenticate endpoint calls. Endpoints can apply the auth
by passing their "Security Requirements" to the authenticate method like
this:

```ts
 const req = this.createRequest('GET', '/auth/basic');
 req.authenticate([{ basicAuth: true }, { accessToken: true }]);
 return req.callAsText(requestOptions);
```

Here, `authenticate()` method accepts a type of "Array of Map". The array
denotes auths combined by OR and the map denotes auths combined by AND. This
is similar to how Security Requirements are defined in OpenAPI definitions.

If the compositeAuthProviderConfig does not satisfy the security requirements
defined by the endpoint, then an exception is thrown.

## How to update the SDKs to use multiple auth?

1. Update the requestBuilderFactory initialization code in the `Client` constructor like this:

```diff
+    const authProvider = createAuthProviderFromConfig(this._config);

    this._requestBuilderFactory = createRequestHandlerFactory(
      (server) => getBaseUri(server, this._config),
+      authProvider,
      new HttpClient(AbortError, {
        timeout: this._timeout,
        clientConfigOverrides: this._config.unstable_httpClientOptions,
        httpAgent: this._config.httpClientOptions?.httpAgent,
        httpsAgent: this._config.httpClientOptions?.httpsAgent,
      }),
      [withErrorHandlers, withUserAgent],
      this._retryConfig
    );
```

2. Define the `createAuthProviderFromConfig` in a new file called `authProvider.ts`. Here's an example that uses access token and basic auth:

```ts
import {
  accessTokenAuthenticationProvider,
  basicAuthenticationProvider,
} from './authentication';
import { Configuration } from './configuration';
import { compositeAuthenticationProvider } from './core';

export function createAuthProviderFromConfig(config: Partial<Configuration>) {
  const authConfig = {
    accessToken:
      config.accessTokenCredentials &&
      accessTokenAuthenticationProvider(config.accessTokenCredentials),
    basicAuth:
      config.basicAuthCredentials &&
      basicAuthenticationProvider(
        config.basicAuthCredentials.username,
        config.basicAuthCredentials.password
      ),
  };

  return compositeAuthenticationProvider<
    keyof typeof authConfig,
    typeof authConfig
  >(authConfig);
}
```

3. Update the `AuthParams` type in the `clientInterface.ts` file like this:

```ts
export type AuthParams = ReturnType<typeof createAuthProviderFromConfig> extends AuthenticatorInterface<infer X> ? X : never;
```

4. Finally, you can now use the multiple auth by defining the security requirements in the endpoint like this:

```diff
  async getBasicAuthTest(
    requestOptions?: RequestOptions
  ): Promise<ApiResponse<string>> {
    const req = this.createRequest('GET', '/auth/basic');
+    req.authenticate([{ accessToken: true }, { basicAuth: true }]);
    return req.callAsText(requestOptions);
  }
```