### PR TITLE
fix(schema): fix mapping of all optional fields model array to its object schema

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apimatic/schema",
   "author": "APIMatic Ltd.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "license": "MIT",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/schema/src/types/object.ts
+++ b/packages/schema/src/types/object.ts
@@ -204,6 +204,13 @@ function validateObjectBeforeMapXml(
     if (typeof value !== 'object' || value === null) {
       return ctxt.fail();
     }
+    if (Array.isArray(value)) {
+      return ctxt.fail(
+        `Expected value to be of type '${
+          ctxt.type
+        }' but found 'Array<${typeof value}>'.`
+      );
+    }
     const valueObject = value as {
       $?: Record<string, unknown>;
       [key: string]: unknown;
@@ -414,6 +421,13 @@ function validateObject(
   return (value: unknown, ctxt: SchemaContextCreator) => {
     if (typeof value !== 'object' || value === null) {
       return ctxt.fail();
+    }
+    if (Array.isArray(value)) {
+      return ctxt.fail(
+        `Expected value to be of type '${
+          ctxt.type
+        }' but found 'Array<${typeof value}>'.`
+      );
     }
     return validateValueObject({
       validationMethod,

--- a/packages/schema/test/types.ts
+++ b/packages/schema/test/types.ts
@@ -14,6 +14,16 @@ export const animalSchema: Schema<Animal> = object({
   age: ['age', number()],
 });
 
+export interface AllOptional {
+  name?: string;
+  age?: number;
+}
+
+export const allOptionalSchema: Schema<AllOptional> = object({
+  name: ['name', optional(string())],
+  age: ['age', optional(number())],
+});
+
 export interface Human {
   name: string;
   age: number;

--- a/packages/schema/test/types/oneOf.test.ts
+++ b/packages/schema/test/types/oneOf.test.ts
@@ -9,6 +9,8 @@ import { employeeSchema } from '../employeeSchema';
 import {
   Address,
   addressSchema,
+  AllOptional,
+  allOptionalSchema,
   Animal,
   animalSchema,
   Color,
@@ -190,6 +192,23 @@ describe('OnyOf', () => {
     it('should map oneOf with nullable complex types', () => {
       const input: Human | null = null;
       const schema = oneOf([humanSchema, nullable(humanSchema)]);
+      const output = validateAndMap(input, schema);
+      expect(output.errors).toBeFalsy();
+      expect((output as any).result).toStrictEqual(input);
+    });
+
+    it('should map oneOf with array and array of object with all optional properties', () => {
+      const input: AllOptional[] = [
+        {
+          name: 'John',
+          age: 30,
+        },
+        {
+          name: 'John',
+          age: 30,
+        },
+      ];
+      const schema = oneOf([allOptionalSchema, array(allOptionalSchema)]);
       const output = validateAndMap(input, schema);
       expect(output.errors).toBeFalsy();
       expect((output as any).result).toStrictEqual(input);


### PR DESCRIPTION
The array of model with all optional fields gets mapped to optional model schema which creates a case of one of failure in which an all optional field object gets mapped to  its relevant object schema and array of object schema as well.

closes #151