### PR TITLE
feat(auto-refresh-fetch): enable auto refresh and fetch oauth token flow

### DIFF
--- a/packages/oauth-adapters/package.json
+++ b/packages/oauth-adapters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apimatic/oauth-adapters",
   "author": "APIMatic Ltd.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/oauth-adapters/src/oAuthToken.ts
+++ b/packages/oauth-adapters/src/oAuthToken.ts
@@ -1,4 +1,10 @@
-import { bigint, object, optional, Schema, string } from '@apimatic/schema';
+import {
+  bigint,
+  expandoObject,
+  optional,
+  Schema,
+  string,
+} from '@apimatic/schema';
 
 /** OAuth 2 Authorization endpoint response */
 export interface OAuthToken {
@@ -20,9 +26,10 @@ export interface OAuthToken {
    * Used to get a new access token when it expires.
    */
   refreshToken?: string;
+  [key: string]: unknown;
 }
 
-export const oAuthTokenSchema: Schema<OAuthToken> = object({
+export const oAuthTokenSchema: Schema<OAuthToken> = expandoObject({
   accessToken: ['access_token', string()],
   tokenType: ['token_type', string()],
   expiresIn: ['expires_in', optional(bigint())],

--- a/packages/oauth-adapters/src/oAuthToken.ts
+++ b/packages/oauth-adapters/src/oAuthToken.ts
@@ -1,10 +1,4 @@
-import {
-  bigint,
-  expandoObject,
-  optional,
-  Schema,
-  string,
-} from '@apimatic/schema';
+import { bigint, object, optional, Schema, string } from '@apimatic/schema';
 
 /** OAuth 2 Authorization endpoint response */
 export interface OAuthToken {
@@ -26,10 +20,9 @@ export interface OAuthToken {
    * Used to get a new access token when it expires.
    */
   refreshToken?: string;
-  [key: string]: unknown;
 }
 
-export const oAuthTokenSchema: Schema<OAuthToken> = expandoObject({
+export const oAuthTokenSchema: Schema<OAuthToken> = object({
   accessToken: ['access_token', string()],
   tokenType: ['token_type', string()],
   expiresIn: ['expires_in', optional(bigint())],

--- a/packages/oauth-adapters/src/oauthAuthenticationAdapter.ts
+++ b/packages/oauth-adapters/src/oauthAuthenticationAdapter.ts
@@ -6,15 +6,45 @@ import {
 import { AUTHORIZATION_HEADER, setHeader } from '@apimatic/http-headers';
 
 export const requestAuthenticationProvider = (
-  oAuthToken?: OAuthToken
+  initialOAuthToken?: OAuthToken,
+  oAuthTokenProvider?: (token: OAuthToken | undefined) => Promise<OAuthToken>,
+  oAuthOnTokenUpdate?: (token: OAuthToken) => void
 ): AuthenticatorInterface<boolean> => {
+  // This token is shared between all API calls for a client instance.
+  let lastOAuthToken: Promise<OAuthToken | undefined> = Promise.resolve(
+    initialOAuthToken
+  );
+
   return (requiresAuth?: boolean) => {
     if (!requiresAuth) {
       return passThroughInterceptor;
     }
 
-    validateAuthorization(oAuthToken);
-    return createRequestInterceptor(oAuthToken);
+    return async (request: any, options: any, next: any) => {
+      let oAuthToken = await lastOAuthToken;
+
+      if (
+        oAuthTokenProvider &&
+        (!isValid(oAuthToken) || isExpired(oAuthToken))
+      ) {
+        // Set the shared token for the next API calls to use.
+        lastOAuthToken = oAuthTokenProvider(oAuthToken);
+        oAuthToken = await lastOAuthToken;
+        if (oAuthOnTokenUpdate && oAuthToken) {
+          oAuthOnTokenUpdate(oAuthToken);
+        }
+      }
+
+      validateAuthorization(oAuthToken);
+      request.headers = request.headers ?? {};
+      setHeader(
+        request.headers,
+        AUTHORIZATION_HEADER,
+        `Bearer ${oAuthToken?.accessToken}`
+      );
+
+      return next(request, options);
+    };
   };
 };
 
@@ -30,19 +60,6 @@ function validateAuthorization(oAuthToken?: OAuthToken) {
       'OAuth token is expired. A valid token is needed to make API calls.'
     );
   }
-}
-
-function createRequestInterceptor(oAuthToken?: OAuthToken) {
-  return (request: any, options: any, next: any) => {
-    request.headers = request.headers ?? {};
-    setHeader(
-      request.headers,
-      AUTHORIZATION_HEADER,
-      `Bearer ${oAuthToken?.accessToken}`
-    );
-
-    return next(request, options);
-  };
 }
 
 function isValid(oAuthToken: OAuthToken | undefined): oAuthToken is OAuthToken {

--- a/packages/oauth-adapters/src/oauthAuthenticationAdapter.ts
+++ b/packages/oauth-adapters/src/oauthAuthenticationAdapter.ts
@@ -22,7 +22,6 @@ export const requestAuthenticationProvider = (
 
     return async (request: any, options: any, next: any) => {
       let oAuthToken = await lastOAuthToken;
-
       if (
         oAuthTokenProvider &&
         (!isValid(oAuthToken) || isExpired(oAuthToken))
@@ -34,19 +33,24 @@ export const requestAuthenticationProvider = (
           oAuthOnTokenUpdate(oAuthToken);
         }
       }
-
-      validateAuthorization(oAuthToken);
-      request.headers = request.headers ?? {};
-      setHeader(
-        request.headers,
-        AUTHORIZATION_HEADER,
-        `Bearer ${oAuthToken?.accessToken}`
-      );
-
+      setOAuthTokenInRequest(oAuthToken, request);
       return next(request, options);
     };
   };
 };
+
+function setOAuthTokenInRequest(
+  oAuthToken: OAuthToken | undefined,
+  request: any
+) {
+  validateAuthorization(oAuthToken);
+  request.headers = request.headers ?? {};
+  setHeader(
+    request.headers,
+    AUTHORIZATION_HEADER,
+    `Bearer ${oAuthToken?.accessToken}`
+  );
+}
 
 function validateAuthorization(oAuthToken?: OAuthToken) {
   if (!isValid(oAuthToken)) {

--- a/packages/oauth-adapters/src/oauthAuthenticationAdapter.ts
+++ b/packages/oauth-adapters/src/oauthAuthenticationAdapter.ts
@@ -20,7 +20,7 @@ export const requestAuthenticationProvider = (
       return passThroughInterceptor;
     }
 
-    return async (request: any, options: any, next: any) => {
+    return async (request, options, next) => {
       let oAuthToken = await lastOAuthToken;
       if (
         oAuthTokenProvider &&

--- a/packages/oauth-adapters/test/oauthAuthenticationAdapter.test.ts
+++ b/packages/oauth-adapters/test/oauthAuthenticationAdapter.test.ts
@@ -2,24 +2,27 @@ import { callHttpInterceptors } from '../../core/src/http/httpInterceptor';
 import { requestAuthenticationProvider } from '../src/oauthAuthenticationAdapter';
 import {
   HttpContext,
+  HttpInterceptorInterface,
   HttpRequest,
   HttpResponse,
+  RequestOptions,
 } from '../../core-interfaces/src';
 import { OAuthToken } from '../src/oAuthToken';
 
 describe('test oauth request provider', () => {
-  it('should test oauth request provider with enabled authentication', async () => {
-    const response: HttpResponse = {
-      statusCode: 200,
-      body: 'testBody',
-      headers: { 'test-header': 'test-value' },
+  it('should pass with disabled authentication', async () => {
+    const oAuthToken = {
+      accessToken: '1f12495f1a1ad9066b51fb3b4e456aee',
+      tokenType: 'Bearer',
+      expiresIn: BigInt(100000),
+      scope: '[products, orders]',
+      expiry: BigInt(Date.now()),
     };
+    const authenticationProvider = requestAuthenticationProvider(oAuthToken);
+    return await executeAndExpect(authenticationProvider(false), undefined);
+  });
 
-    const request: HttpRequest = {
-      method: 'GET',
-      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
-    };
-
+  it('should pass with valid token', async () => {
     const oAuthToken: OAuthToken = {
       accessToken: '1f12495f1a1ad9066b51fb3b4e456aee',
       tokenType: 'Bearer',
@@ -28,62 +31,83 @@ describe('test oauth request provider', () => {
       expiry: BigInt(Date.now()),
     };
     const authenticationProvider = requestAuthenticationProvider(oAuthToken);
-    let context: HttpContext = { request, response };
-    const handler = authenticationProvider(true);
-    const interceptor = [handler];
-    const client = async (req) => {
-      return { request: req, response };
-    };
-    const executor = callHttpInterceptors(interceptor, client);
-    context = await executor(request, undefined);
-    return expect(context.request.headers).toEqual({
+    return await executeAndExpect(authenticationProvider(true), {
       authorization: 'Bearer 1f12495f1a1ad9066b51fb3b4e456aee',
     });
   });
 
-  it('should test oauth request provider with disabled authentication', async () => {
-    const response: HttpResponse = {
-      statusCode: 200,
-      body: 'testBody',
-      headers: { 'test-header': 'test-value' },
-    };
-
-    const request: HttpRequest = {
-      method: 'GET',
-      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
-    };
-
-    const oAuthToken = {
+  it('should pass with valid token + authProvider + updateCallback', async () => {
+    const oAuthToken: OAuthToken = {
       accessToken: '1f12495f1a1ad9066b51fb3b4e456aee',
       tokenType: 'Bearer',
       expiresIn: BigInt(100000),
       scope: '[products, orders]',
       expiry: BigInt(Date.now()),
     };
-    const authenticationProvider = requestAuthenticationProvider(oAuthToken);
-    let context: HttpContext = { request, response };
-    const handler = authenticationProvider(false);
-    const interceptor = [handler];
-    const client = async (req) => {
-      return { request: req, response };
-    };
-    const executor = callHttpInterceptors(interceptor, client);
-    context = await executor(request, undefined);
-    return expect(context.request.headers).toBeUndefined();
+    const authenticationProvider = requestAuthenticationProvider(
+      oAuthToken,
+      (token: OAuthToken | undefined) => {
+        // return an invalid token if accessed from provider
+        if (token === undefined) {
+          return Promise.resolve({
+            accessToken: 'Invalid',
+            tokenType: 'Bearer',
+          });
+        }
+        return Promise.resolve({
+          ...token,
+          accessToken: 'Invalid',
+        });
+      },
+      (_: OAuthToken) => {
+        // fail if token gets updated
+        expect(true).toBe(false);
+      }
+    );
+    return await executeAndExpect(authenticationProvider(true), {
+      authorization: 'Bearer 1f12495f1a1ad9066b51fb3b4e456aee',
+    });
   });
 
-  it('should test oauth request provider with enabled authentication and expired token', async () => {
-    const response: HttpResponse = {
-      statusCode: 200,
-      body: 'testBody',
-      headers: { 'test-header': 'test-value' },
-    };
+  it('should fail with undefined token', async () => {
+    const authenticationProvider = requestAuthenticationProvider();
+    return await executeAndExpect(
+      authenticationProvider(true),
+      undefined,
+      'Client is not authorized. An OAuth token is needed to make API calls.'
+    );
+  });
 
-    const request: HttpRequest = {
-      method: 'GET',
-      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
-    };
+  it('should pass with undefined token + authProvider + updateCallback', async () => {
+    const authenticationProvider = requestAuthenticationProvider(
+      undefined,
+      (token: OAuthToken | undefined) => {
+        if (token === undefined) {
+          return Promise.resolve({
+            accessToken: '1f12495f1a1ad9066b51fb3b4e456aee',
+            tokenType: 'Bearer',
+            expiresIn: BigInt(100000),
+            scope: '[products, orders]',
+            expiry: BigInt(Date.now()),
+          });
+        }
+        // return an invalid token if existing token is not undefined
+        return Promise.resolve({
+          ...token,
+          accessToken: 'Invalid',
+        });
+      },
+      (token: OAuthToken) => {
+        // check the updated token
+        expect(token.accessToken).toBe('1f12495f1a1ad9066b51fb3b4e456aee');
+      }
+    );
+    return await executeAndExpect(authenticationProvider(true), {
+      authorization: 'Bearer 1f12495f1a1ad9066b51fb3b4e456aee',
+    });
+  });
 
+  it('should fail with expired token', async () => {
     const oAuthToken = {
       accessToken: '1f12495f1a1ad9066b51fb3b4e456aee',
       tokenType: 'Bearer',
@@ -91,52 +115,77 @@ describe('test oauth request provider', () => {
       scope: '[products, orders]',
       expiry: BigInt(2000),
     };
-    try {
-      const authenticationProvider = requestAuthenticationProvider(oAuthToken);
-      const handler = authenticationProvider(true);
-      const interceptor = [handler];
-      const client = async (req) => {
-        return { request: req, response };
-      };
-      const executor = callHttpInterceptors(interceptor, client);
-      const context = await executor(request, undefined);
-      expect(context.request.headers).toBeUndefined();
-    } catch (error) {
-      const { message } = error as Error;
-      expect(message).toEqual(
-        'OAuth token is expired. A valid token is needed to make API calls.'
-      );
-    }
+    const authenticationProvider = requestAuthenticationProvider(oAuthToken);
+    return await executeAndExpect(
+      authenticationProvider(true),
+      undefined,
+      'OAuth token is expired. A valid token is needed to make API calls.'
+    );
   });
 
-  it('should test oauth request provider with enabled authentication and undefined token', async () => {
-    const response: HttpResponse = {
-      statusCode: 200,
-      body: 'testBody',
-      headers: { 'test-header': 'test-value' },
+  it('should pass with expired token + authProvider + updateCallback', async () => {
+    const oAuthToken = {
+      accessToken: '1f12495f1a1ad9066b51fb3b4e456aee',
+      tokenType: 'Bearer',
+      expiresIn: BigInt(100000),
+      scope: '[products, orders]',
+      expiry: BigInt(2000),
     };
 
-    const request: HttpRequest = {
-      method: 'GET',
-      url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
-    };
-
-    try {
-      const authenticationProvider = requestAuthenticationProvider();
-      let context: HttpContext = { request, response };
-      const handler = authenticationProvider(true);
-      const interceptor = [handler];
-      const client = async (req) => {
-        return { request: req, response };
-      };
-      const executor = callHttpInterceptors(interceptor, client);
-      context = await executor(request, undefined);
-      expect(context.request.headers).toBeUndefined();
-    } catch (error) {
-      const { message } = error as Error;
-      expect(message).toEqual(
-        'Client is not authorized. An OAuth token is needed to make API calls.'
-      );
-    }
+    const authenticationProvider = requestAuthenticationProvider(
+      oAuthToken,
+      (token: OAuthToken | undefined) => {
+        if (token === undefined) {
+          // return an invalid token if existing token is undefined
+          return Promise.resolve({
+            accessToken: 'Invalid',
+            tokenType: 'Bearer',
+          });
+        }
+        return Promise.resolve({
+          ...token,
+          accessToken: '1f12495f1a1ad9066b51fb3b4e456aeeNEW',
+          expiry: BigInt(Date.now()),
+        });
+      },
+      (token: OAuthToken) => {
+        // check the updated token
+        expect(token.accessToken).toBe('1f12495f1a1ad9066b51fb3b4e456aeeNEW');
+      }
+    );
+    return await executeAndExpect(authenticationProvider(true), {
+      authorization: 'Bearer 1f12495f1a1ad9066b51fb3b4e456aeeNEW',
+    });
   });
 });
+
+async function executeAndExpect(
+  authenticationProvider: HttpInterceptorInterface<RequestOptions | undefined>,
+  headers: Record<string, string> | undefined,
+  errorMessage?: string
+) {
+  const response: HttpResponse = {
+    statusCode: 200,
+    body: 'testBody',
+    headers: { 'test-header': 'test-value' },
+  };
+
+  const request: HttpRequest = {
+    method: 'GET',
+    url: 'http://apimatic.hopto.org:3000/test/requestBuilder',
+  };
+  let context: HttpContext = { request, response };
+  try {
+    const interceptor = [authenticationProvider];
+    const client = async (req: any) => {
+      return { request: req, response };
+    };
+    const executor = callHttpInterceptors(interceptor, client);
+    context = await executor(request, undefined);
+    expect(context.request.headers).toEqual(headers);
+  } catch (error) {
+    expect(errorMessage === undefined).toBe(false);
+    const { message } = error as Error;
+    expect(message).toEqual(errorMessage);
+  }
+}


### PR DESCRIPTION
This PR adds the functionality i.e. a provider to fetch or refresh the OAuth token again, whenever it meets the following criteria:
- It gets expired
- It is undefined

This PR also adds the functionality to get updated OAuthToken via a callback function that can be used to store it wherever necessary

Closes #161 