### PR TITLE
fix(nullable-headers): adds the capability to set null headers in request builder

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apimatic/core",
   "author": "APIMatic Ltd.",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "license": "MIT",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/core/src/http/requestBuilder.ts
+++ b/packages/core/src/http/requestBuilder.ts
@@ -55,6 +55,7 @@ import {
 } from './retryConfiguration';
 import { convertToStream } from '@apimatic/convert-to-stream';
 import { XmlSerializerInterface, XmlSerialization } from '../xml/xmlSerializer';
+import { util } from 'prettier';
 
 export type RequestBuilderFactory<BaseUrlParamType, AuthParams> = (
   httpMethod: HttpMethod,
@@ -116,7 +117,7 @@ export interface RequestBuilder<BaseUrlParamType, AuthParams> {
   acceptJson(): void;
   accept(acceptHeaderValue: string): void;
   contentType(contentTypeHeaderValue: string): void;
-  header(name: string, value?: string | boolean | number | bigint): void;
+  header(name: string, value?: string | boolean | number | bigint | null): void;
   headers(headersToMerge: Record<string, string>): void;
   query(
     name: string,
@@ -277,9 +278,9 @@ export class DefaultRequestBuilder<BaseUrlParamType, AuthParams>
   }
   public header(
     name: string,
-    value?: string | boolean | number | bigint
+    value?: string | boolean | number | bigint | null
   ): void {
-    if (value === undefined) {
+    if (value === null || typeof value === 'undefined') {
       return;
     }
     setHeader(this._headers, name, value.toString());

--- a/packages/core/src/http/requestBuilder.ts
+++ b/packages/core/src/http/requestBuilder.ts
@@ -55,7 +55,6 @@ import {
 } from './retryConfiguration';
 import { convertToStream } from '@apimatic/convert-to-stream';
 import { XmlSerializerInterface, XmlSerialization } from '../xml/xmlSerializer';
-import { util } from 'prettier';
 
 export type RequestBuilderFactory<BaseUrlParamType, AuthParams> = (
   httpMethod: HttpMethod,

--- a/packages/core/test/http/requestBuilder.test.ts
+++ b/packages/core/test/http/requestBuilder.test.ts
@@ -337,11 +337,12 @@ describe('test default request builder behavior with succesful responses', () =>
       body: 'testBody result',
     });
   });
-  it('should test request builder with undefined header, query, empty path', async () => {
+  it('should test request builder with undefined and null header, query, empty path', async () => {
     const reqBuilder = defaultRequestBuilder('GET', 'test/requestBuilder');
     reqBuilder.baseUrl('default');
     reqBuilder.appendPath('');
     reqBuilder.header('test-header');
+    reqBuilder.header('test-header', null);
     reqBuilder.query();
     reqBuilder.stream();
     const request = reqBuilder.toRequest();


### PR DESCRIPTION
This PR adds the capability in the requestBuilder's instance to also accept header value `null`

### Before

```
header(name: string, value?: string | boolean | number | bigint)
```

### After

```
header(name: string, value?: string | boolean | number | bigint | null)
```