### PR TITLE
feat(oauth-expiry): add clock skew support in oauth token expiry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# JetBrains IDE configuration files
+.idea/
+
 ### VisualStudioCode ###
 .vscode/*
 !.vscode/tasks.json

--- a/packages/oauth-adapters/src/index.ts
+++ b/packages/oauth-adapters/src/index.ts
@@ -1,1 +1,2 @@
 export * from './oauthAuthenticationAdapter';
+export * from './oAuthConfiguration';

--- a/packages/oauth-adapters/src/oAuthConfiguration.ts
+++ b/packages/oauth-adapters/src/oAuthConfiguration.ts
@@ -1,0 +1,4 @@
+/** An interface for OAuth configuration */
+export interface OAuthConfiguration {
+  clockSkew?: number;
+}

--- a/packages/oauth-adapters/src/oauthAuthenticationAdapter.ts
+++ b/packages/oauth-adapters/src/oauthAuthenticationAdapter.ts
@@ -4,11 +4,13 @@ import {
   passThroughInterceptor,
 } from '@apimatic/core-interfaces';
 import { AUTHORIZATION_HEADER, setHeader } from '@apimatic/http-headers';
+import { OAuthConfiguration } from './oAuthConfiguration';
 
 export const requestAuthenticationProvider = (
   initialOAuthToken?: OAuthToken,
   oAuthTokenProvider?: (token: OAuthToken | undefined) => Promise<OAuthToken>,
-  oAuthOnTokenUpdate?: (token: OAuthToken) => void
+  oAuthOnTokenUpdate?: (token: OAuthToken) => void,
+  oAuthConfiguration?: OAuthConfiguration
 ): AuthenticatorInterface<boolean> => {
   // This token is shared between all API calls for a client instance.
   let lastOAuthToken: Promise<OAuthToken | undefined> = Promise.resolve(
@@ -24,7 +26,8 @@ export const requestAuthenticationProvider = (
       let oAuthToken = await lastOAuthToken;
       if (
         oAuthTokenProvider &&
-        (!isValid(oAuthToken) || isExpired(oAuthToken))
+        (!isValid(oAuthToken) ||
+          isExpired(oAuthToken, oAuthConfiguration?.clockSkew))
       ) {
         // Set the shared token for the next API calls to use.
         lastOAuthToken = oAuthTokenProvider(oAuthToken);
@@ -70,9 +73,17 @@ function isValid(oAuthToken: OAuthToken | undefined): oAuthToken is OAuthToken {
   return typeof oAuthToken !== 'undefined';
 }
 
-function isExpired(oAuthToken: OAuthToken) {
-  return (
-    typeof oAuthToken.expiry !== 'undefined' &&
-    oAuthToken.expiry < Date.now() / 1000
-  );
+function isExpired(oAuthToken: OAuthToken, clockSkew?: number) {
+  if (typeof oAuthToken.expiry === 'undefined') {
+    return false; // Expiry is undefined, token cannot be expired
+  }
+
+  let tokenExpiry = oAuthToken.expiry;
+
+  // Adjust expiration time if clockSkew is provided and is not undefined
+  if (clockSkew && typeof clockSkew !== 'undefined') {
+    tokenExpiry -= BigInt(clockSkew); // Subtract clockSkew from expiry
+  }
+
+  return tokenExpiry < Date.now() / 1000;
 }

--- a/packages/oauth-adapters/src/oauthAuthenticationAdapter.ts
+++ b/packages/oauth-adapters/src/oauthAuthenticationAdapter.ts
@@ -69,11 +69,13 @@ function validateAuthorization(oAuthToken?: OAuthToken) {
   }
 }
 
-function isValid(oAuthToken: OAuthToken | undefined): oAuthToken is OAuthToken {
+export function isValid(
+  oAuthToken: OAuthToken | undefined
+): oAuthToken is OAuthToken {
   return typeof oAuthToken !== 'undefined';
 }
 
-function isExpired(oAuthToken: OAuthToken, clockSkew?: number) {
+export function isExpired(oAuthToken: OAuthToken, clockSkew?: number) {
   if (typeof oAuthToken.expiry === 'undefined') {
     return false; // Expiry is undefined, token cannot be expired
   }

--- a/packages/oauth-adapters/src/oauthAuthenticationAdapter.ts
+++ b/packages/oauth-adapters/src/oauthAuthenticationAdapter.ts
@@ -36,7 +36,11 @@ export const requestAuthenticationProvider = (
           oAuthOnTokenUpdate(oAuthToken);
         }
       }
-      setOAuthTokenInRequest(oAuthToken, request);
+      setOAuthTokenInRequest(
+        oAuthToken,
+        request,
+        oAuthConfiguration?.clockSkew
+      );
       return next(request, options);
     };
   };
@@ -44,9 +48,10 @@ export const requestAuthenticationProvider = (
 
 function setOAuthTokenInRequest(
   oAuthToken: OAuthToken | undefined,
-  request: any
+  request: any,
+  clockSkew?: number
 ) {
-  validateAuthorization(oAuthToken);
+  validateAuthorization(oAuthToken, clockSkew);
   request.headers = request.headers ?? {};
   setHeader(
     request.headers,
@@ -55,14 +60,14 @@ function setOAuthTokenInRequest(
   );
 }
 
-function validateAuthorization(oAuthToken?: OAuthToken) {
+function validateAuthorization(oAuthToken?: OAuthToken, clockSkew?: number) {
   if (!isValid(oAuthToken)) {
     throw new Error(
       'Client is not authorized. An OAuth token is needed to make API calls.'
     );
   }
 
-  if (isExpired(oAuthToken)) {
+  if (isExpired(oAuthToken, clockSkew)) {
     throw new Error(
       'OAuth token is expired. A valid token is needed to make API calls.'
     );

--- a/packages/oauth-adapters/test/oauthAuthenticationAdapter.test.ts
+++ b/packages/oauth-adapters/test/oauthAuthenticationAdapter.test.ts
@@ -8,7 +8,7 @@ import {
   RequestOptions,
 } from '../../core-interfaces/src';
 import { OAuthToken } from '../src/oAuthToken';
-import { isExpired, OAuthConfiguration } from '../lib';
+import { isExpired, isValid, OAuthConfiguration } from '../lib';
 
 describe('test oauth request provider', () => {
   it('should pass with disabled authentication', async () => {
@@ -169,6 +169,30 @@ describe('test oauth request provider', () => {
     expect(oAuthOnTokenUpdate.mock.calls[0][0].accessToken).toBe(
       '1f12495f1a1ad9066b51fb3b4e456aeeNEW'
     );
+  });
+});
+
+describe('isValid', () => {
+  it('should return false if oAuthToken is undefined', () => {
+    const token: OAuthToken | undefined = undefined;
+    expect(isValid(token)).toBe(false);
+  });
+
+  it('should return true if oAuthToken is defined', () => {
+    const token: OAuthToken = {
+      accessToken: '1f12495f1a1ad9066b51fb3b4e456aee',
+      tokenType: 'Bearer',
+      expiry: BigInt(Math.floor(Date.now() / 1000) + 60),
+    };
+    expect(isValid(token)).toBe(true);
+  });
+
+  it('should return true if oAuthToken is defined with no expiry', () => {
+    const token: OAuthToken = {
+      accessToken: '1f12495f1a1ad9066b51fb3b4e456aee',
+      tokenType: 'Bearer',
+    };
+    expect(isValid(token)).toBe(true);
   });
 });
 

--- a/packages/oauth-adapters/test/oauthAuthenticationAdapter.test.ts
+++ b/packages/oauth-adapters/test/oauthAuthenticationAdapter.test.ts
@@ -201,6 +201,7 @@ describe('isExpired', () => {
     const token: OAuthToken = {
       accessToken: '1f12495f1a1ad9066b51fb3b4e456aee',
       tokenType: 'Bearer',
+      expiry: undefined,
     };
     expect(isExpired(token)).toBe(false);
   });

--- a/packages/oauth-adapters/test/oauthAuthenticationAdapter.test.ts
+++ b/packages/oauth-adapters/test/oauthAuthenticationAdapter.test.ts
@@ -8,6 +8,7 @@ import {
   RequestOptions,
 } from '../../core-interfaces/src';
 import { OAuthToken } from '../src/oAuthToken';
+import { OAuthConfiguration } from '../lib';
 
 describe('test oauth request provider', () => {
   it('should pass with disabled authentication', async () => {
@@ -156,6 +157,56 @@ describe('test oauth request provider', () => {
       oAuthToken,
       oAuthTokenProvider,
       oAuthOnTokenUpdate
+    );
+    await executeAndExpect(authenticationProvider(true), {
+      authorization: 'Bearer 1f12495f1a1ad9066b51fb3b4e456aeeNEW',
+    });
+    expect(oAuthTokenProvider.mock.calls).toHaveLength(1);
+    expect(oAuthTokenProvider.mock.calls[0][0]?.accessToken).toBe(
+      '1f12495f1a1ad9066b51fb3b4e456aee'
+    );
+    expect(oAuthOnTokenUpdate.mock.calls).toHaveLength(1);
+    expect(oAuthOnTokenUpdate.mock.calls[0][0].accessToken).toBe(
+      '1f12495f1a1ad9066b51fb3b4e456aeeNEW'
+    );
+  });
+});
+
+describe('isExpired', () => {
+  it('should pass with non expired token + authProvider + updateCallback', async () => {
+    const oneMinOffset: number = 60;
+    const oAuthToken = {
+      accessToken: '1f12495f1a1ad9066b51fb3b4e456aee',
+      tokenType: 'Bearer',
+      scope: 'products orders',
+      expiry: BigInt(Date.now() + oneMinOffset) / BigInt(1000),
+    };
+    const oAuthConfiguration: OAuthConfiguration = {
+      clockSkew: oneMinOffset * 2,
+    };
+    const oAuthTokenProvider = jest.fn((token: OAuthToken | undefined) => {
+      if (token === undefined) {
+        // return an invalid token if existing token is undefined
+        return Promise.resolve({
+          accessToken: 'Invalid',
+          tokenType: 'Bearer',
+        });
+      }
+      return Promise.resolve({
+        ...token,
+        accessToken: '1f12495f1a1ad9066b51fb3b4e456aeeNEW',
+        expiry: BigInt(Date.now()),
+      });
+    });
+    const oAuthOnTokenUpdate = jest.fn((_: OAuthToken) => {
+      // handler for updated token
+    });
+
+    const authenticationProvider = requestAuthenticationProvider(
+      oAuthToken,
+      oAuthTokenProvider,
+      oAuthOnTokenUpdate,
+      oAuthConfiguration
     );
     await executeAndExpect(authenticationProvider(true), {
       authorization: 'Bearer 1f12495f1a1ad9066b51fb3b4e456aeeNEW',


### PR DESCRIPTION
This PR adds the support for clockSkew (in seconds) to allow the token to refresh before the actual token expiry. This configuration is optional and by default actual token expiry would be used to refresh the OAuth Token.

### The Need for Skew Time
Clocks on different servers can have slight discrepancies, even when synchronized. This can lead to issues where a client attempts to use a token shortly before its calculated expiry on the client-side, but the token is already expired on the server-side. Implementing skew time adds a buffer to the calculated expiry, mitigating this risk.

### Proposed Change
The change involves introducing a skew time parameter to the isExpired method. This parameter will represent a time offset (likely in seconds) that will be subtracted from the expiry time based on the OAuthToken Expiry

Closes #174 