### PR TITLE
feat(optional-nullable): adds optional nullable support in schema lib

### DIFF
--- a/packages/core/test/http/apiLogger.test.ts
+++ b/packages/core/test/http/apiLogger.test.ts
@@ -33,7 +33,7 @@ describe('Test APILogger with Request ConsoleLogging', () => {
   });
   it('should override log req default level', async () => {
     const loggingOpts = mergeLoggingOptions({
-      logLevel: 'info',
+      logLevel: LogLevel.Debug,
     });
 
     const expectedConsoleLogs = [

--- a/packages/core/test/http/apiLogger.test.ts
+++ b/packages/core/test/http/apiLogger.test.ts
@@ -33,7 +33,7 @@ describe('Test APILogger with Request ConsoleLogging', () => {
   });
   it('should override log req default level', async () => {
     const loggingOpts = mergeLoggingOptions({
-      logLevel: LogLevel.Debug,
+      logLevel: 'info',
     });
 
     const expectedConsoleLogs = [

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -1,4 +1,4 @@
-import { objectKeyEncode } from './utils';
+import { isOptionalNullable, objectKeyEncode } from './utils';
 
 /**
  * Schema defines a type and its validation and mapping functions.
@@ -101,6 +101,9 @@ export function validateAndMap<T extends Schema<any, any>>(
   );
   const validationResult = schema.validateBeforeMap(value, contextCreator);
   if (validationResult.length === 0) {
+    if (isOptionalNullable(schema.type())) {
+      return { errors: false, result: value };
+    }
     return { errors: false, result: schema.map(value, contextCreator) };
   } else {
     return { errors: validationResult };

--- a/packages/schema/src/utils.ts
+++ b/packages/schema/src/utils.ts
@@ -157,6 +157,8 @@ export function isNullOrMissing(value: unknown): value is null | undefined {
 }
 
 export function isOptionalNullable(type: string): boolean {
-  return type.startsWith('Optional<Nullable<') ||
-    type.startsWith('Nullable<Optional<');
+  return (
+    type.startsWith('Optional<Nullable<') ||
+    type.startsWith('Nullable<Optional<')
+  );
 }

--- a/packages/schema/src/utils.ts
+++ b/packages/schema/src/utils.ts
@@ -155,3 +155,8 @@ export function objectKeyEncode(key: string): string {
 export function isNullOrMissing(value: unknown): value is null | undefined {
   return value === null || typeof value === 'undefined';
 }
+
+export function isOptionalNullable(type: string): boolean {
+  return type.startsWith('Optional<Nullable<') ||
+    type.startsWith('Nullable<Optional<');
+}

--- a/packages/schema/test/types/nullable.test.ts
+++ b/packages/schema/test/types/nullable.test.ts
@@ -1,4 +1,4 @@
-import { nullable, string, validateAndMap, validateAndUnmap } from '../../src';
+import { nullable, optional, string, validateAndMap, validateAndUnmap } from '../../src';
 
 describe('Nullable', () => {
   describe('Mapping', () => {
@@ -22,6 +22,20 @@ describe('Nullable', () => {
       const output = validateAndMap(undefined, schema);
       expect(output.errors).toBeFalsy();
       expect((output as any).result).toBeNull();
+    });
+
+    it('should accept null with nullable and optional', () => {
+      const schema = nullable(optional(string()));
+      const output = validateAndMap(null, schema);
+      expect(output.errors).toBeFalsy();
+      expect((output as any).result).toBeNull();
+    });
+
+    it('should accept undefined with nullable and optional', () => {
+      const schema = nullable(optional(string()));
+      const output = validateAndMap(undefined, schema);
+      expect(output.errors).toBeFalsy();
+      expect((output as any).result).toBeUndefined();
     });
 
     it('should fail on schema invalidation', () => {

--- a/packages/schema/test/types/nullable.test.ts
+++ b/packages/schema/test/types/nullable.test.ts
@@ -1,4 +1,10 @@
-import { nullable, optional, string, validateAndMap, validateAndUnmap } from '../../src';
+import {
+  nullable,
+  optional,
+  string,
+  validateAndMap,
+  validateAndUnmap,
+} from '../../src';
 
 describe('Nullable', () => {
   describe('Mapping', () => {

--- a/packages/schema/test/types/optional.test.ts
+++ b/packages/schema/test/types/optional.test.ts
@@ -1,4 +1,10 @@
-import { nullable, optional, string, validateAndMap, validateAndUnmap } from '../../src';
+import {
+  nullable,
+  optional,
+  string,
+  validateAndMap,
+  validateAndUnmap,
+} from '../../src';
 
 describe('Optional', () => {
   describe('Mapping', () => {

--- a/packages/schema/test/types/optional.test.ts
+++ b/packages/schema/test/types/optional.test.ts
@@ -1,4 +1,4 @@
-import { optional, string, validateAndMap, validateAndUnmap } from '../../src';
+import { nullable, optional, string, validateAndMap, validateAndUnmap } from '../../src';
 
 describe('Optional', () => {
   describe('Mapping', () => {
@@ -20,6 +20,20 @@ describe('Optional', () => {
     it('should accept null as undefined', () => {
       const schema = optional(string());
       const output = validateAndMap(null, schema);
+      expect(output.errors).toBeFalsy();
+      expect((output as any).result).toBeUndefined();
+    });
+
+    it('should accept null with optional and nullable', () => {
+      const schema = optional(nullable(string()));
+      const output = validateAndMap(null, schema);
+      expect(output.errors).toBeFalsy();
+      expect((output as any).result).toBeNull();
+    });
+
+    it('should accept undefined with optional and nullable', () => {
+      const schema = optional(nullable(string()));
+      const output = validateAndMap(undefined, schema);
       expect(output.errors).toBeFalsy();
       expect((output as any).result).toBeUndefined();
     });


### PR DESCRIPTION
This PR adds the capability to retain actual value based on the type of schema provided to schema lib for validation only if optional and nullable schemas are combined