### PR TITLE
feat: added support for handling empty responses with nullable types

### DIFF
--- a/packages/core/src/http/requestBuilder.ts
+++ b/packages/core/src/http/requestBuilder.ts
@@ -499,7 +499,12 @@ export class DefaultRequestBuilder<BaseUrlParamType, AuthParams>
       return { ...request, headers };
     });
     const result = await this.call(requestOptions);
-    if (result.body === '') {
+    if (typeof result.body !== 'string') {
+      throw new Error(
+        'Could not parse body as JSON. The response body is not a string.'
+      );
+    }
+    if (result.body.toString().trim() === '') {
       // Try mapping the missing body as null
       const nullMappingResult = validateAndMap(null, schema);
       if (nullMappingResult.errors) {
@@ -508,11 +513,6 @@ export class DefaultRequestBuilder<BaseUrlParamType, AuthParams>
         );
       }
       return { ...result, result: nullMappingResult.result };
-    }
-    if (typeof result.body !== 'string') {
-      throw new Error(
-        'Could not parse body as JSON. The response body is not a string.'
-      );
     }
     let parsed: unknown;
     try {

--- a/packages/core/src/http/requestBuilder.ts
+++ b/packages/core/src/http/requestBuilder.ts
@@ -504,7 +504,7 @@ export class DefaultRequestBuilder<BaseUrlParamType, AuthParams>
         'Could not parse body as JSON. The response body is not a string.'
       );
     }
-    if (result.body.toString().trim() === '') {
+    if (result.body.trim() === '') {
       // Try mapping the missing body as null
       const nullMappingResult = validateAndMap(null, schema);
       if (nullMappingResult.errors) {

--- a/packages/core/src/http/requestBuilder.ts
+++ b/packages/core/src/http/requestBuilder.ts
@@ -500,9 +500,14 @@ export class DefaultRequestBuilder<BaseUrlParamType, AuthParams>
     });
     const result = await this.call(requestOptions);
     if (result.body === '') {
-      throw new Error(
-        'Could not parse body as JSON. The response body is empty.'
-      );
+      // Try mapping the missing body as null
+      const nullMappingResult = validateAndMap(null, schema);
+      if (nullMappingResult.errors) {
+        throw new Error(
+          'Could not parse body as JSON. The response body is empty.'
+        );
+      }
+      return { ...result, result: nullMappingResult.result };
     }
     if (typeof result.body !== 'string') {
       throw new Error(

--- a/packages/core/src/http/requestBuilder.ts
+++ b/packages/core/src/http/requestBuilder.ts
@@ -506,13 +506,7 @@ export class DefaultRequestBuilder<BaseUrlParamType, AuthParams>
     }
     if (result.body.trim() === '') {
       // Try mapping the missing body as null
-      const nullMappingResult = validateAndMap(null, schema);
-      if (nullMappingResult.errors) {
-        throw new Error(
-          'Could not parse body as JSON. The response body is empty.'
-        );
-      }
-      return { ...result, result: nullMappingResult.result };
+      return this.tryMappingAsNull<T>(schema, result);
     }
     let parsed: unknown;
     try {
@@ -526,6 +520,20 @@ export class DefaultRequestBuilder<BaseUrlParamType, AuthParams>
     }
     return { ...result, result: mappingResult.result };
   }
+
+  private tryMappingAsNull<T>(
+    schema: Schema<T, any>,
+    result: ApiResponse<void>
+  ) {
+    const nullMappingResult = validateAndMap(null, schema);
+    if (nullMappingResult.errors) {
+      throw new Error(
+        'Could not parse body as JSON. The response body is empty.'
+      );
+    }
+    return { ...result, result: nullMappingResult.result };
+  }
+
   public async callAsXml<T>(
     rootName: string,
     schema: Schema<T, any>,

--- a/packages/core/test/http/requestBuilder.test.ts
+++ b/packages/core/test/http/requestBuilder.test.ts
@@ -41,6 +41,16 @@ describe('test default request builder behavior with succesful responses', () =>
     httpStatusCodesToRetry: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
     httpMethodsToRetry: ['GET', 'PUT'] as HttpMethod[],
   };
+  const noContentResponse: HttpResponse = {
+    statusCode: 204,
+    body: '',
+    headers: {},
+  };
+  const whitespacedResponse: HttpResponse = {
+    statusCode: 204,
+    body: '  ',
+    headers: {},
+  };
   const basicAuth = mockBasicAuthenticationInterface(authParams);
   const defaultRequestBuilder = createRequestBuilderFactory<string, boolean>(
     mockHttpClientAdapter(),
@@ -488,29 +498,17 @@ describe('test default request builder behavior with succesful responses', () =>
     }
   });
   it('should test response with no content textual types', async () => {
-    const reqBuilder = customRequestBuilder({
-      statusCode: 204,
-      body: '',
-      headers: {},
-    });
+    const reqBuilder = customRequestBuilder(noContentResponse);
     const { result } = await reqBuilder.callAsText();
     expect(result).toEqual('');
   });
   it('should test response with whitespace content textual types', async () => {
-    const reqBuilder = customRequestBuilder({
-      statusCode: 204,
-      body: '  ',
-      headers: {},
-    });
+    const reqBuilder = customRequestBuilder(whitespacedResponse);
     const { result } = await reqBuilder.callAsText();
     expect(result).toEqual('  ');
   });
   it('should test response with no content string cases', async () => {
-    const reqBuilder = customRequestBuilder({
-      statusCode: 204,
-      body: '',
-      headers: {},
-    });
+    const reqBuilder = customRequestBuilder(noContentResponse);
     const nullableString = await reqBuilder.callAsJson(nullable(string()));
     expect(nullableString.result).toEqual(null);
 
@@ -518,11 +516,7 @@ describe('test default request builder behavior with succesful responses', () =>
     expect(optionalString.result).toEqual(undefined);
   });
   it('should test response with whitespace content string cases', async () => {
-    const reqBuilder = customRequestBuilder({
-      statusCode: 204,
-      body: '  ',
-      headers: {},
-    });
+    const reqBuilder = customRequestBuilder(whitespacedResponse);
     const nullableString = await reqBuilder.callAsJson(nullable(string()));
     expect(nullableString.result).toEqual(null);
 
@@ -530,11 +524,7 @@ describe('test default request builder behavior with succesful responses', () =>
     expect(optionalString.result).toEqual(undefined);
   });
   it('should test response with no content boolean cases', async () => {
-    const reqBuilder = customRequestBuilder({
-      statusCode: 204,
-      body: '',
-      headers: {},
-    });
+    const reqBuilder = customRequestBuilder(noContentResponse);
     const nullableString = await reqBuilder.callAsJson(nullable(boolean()));
     expect(nullableString.result).toEqual(null);
 
@@ -542,11 +532,7 @@ describe('test default request builder behavior with succesful responses', () =>
     expect(optionalString.result).toEqual(undefined);
   });
   it('should test response with whitespace content boolean cases', async () => {
-    const reqBuilder = customRequestBuilder({
-      statusCode: 204,
-      body: '  ',
-      headers: {},
-    });
+    const reqBuilder = customRequestBuilder(whitespacedResponse);
     const nullableString = await reqBuilder.callAsJson(nullable(boolean()));
     expect(nullableString.result).toEqual(null);
 
@@ -554,11 +540,7 @@ describe('test default request builder behavior with succesful responses', () =>
     expect(optionalString.result).toEqual(undefined);
   });
   it('should test response with no content object cases', async () => {
-    const reqBuilder = customRequestBuilder({
-      statusCode: 204,
-      body: '',
-      headers: {},
-    });
+    const reqBuilder = customRequestBuilder(noContentResponse);
     const nullableString = await reqBuilder.callAsJson(
       nullable(employeeSchema)
     );
@@ -570,11 +552,7 @@ describe('test default request builder behavior with succesful responses', () =>
     expect(optionalString.result).toEqual(undefined);
   });
   it('should test response with whitespace content object cases', async () => {
-    const reqBuilder = customRequestBuilder({
-      statusCode: 204,
-      body: '  ',
-      headers: {},
-    });
+    const reqBuilder = customRequestBuilder(whitespacedResponse);
     const nullableString = await reqBuilder.callAsJson(
       nullable(employeeSchema)
     );

--- a/packages/core/test/http/requestBuilder.test.ts
+++ b/packages/core/test/http/requestBuilder.test.ts
@@ -431,8 +431,7 @@ describe('test default request builder behavior with succesful responses', () =>
       reqBuilder.validateResponse(false);
       await reqBuilder.callAsJson(employeeSchema);
     } catch (error) {
-      const expectedResult =
-        'Could not parse body as JSON.\n\nExpected \'r\' instead of \'e\'';
+      const expectedResult = `Could not parse body as JSON.\n\nExpected 'r' instead of 'e'`;
       expect(error.message).toEqual(expectedResult);
     }
   });

--- a/packages/core/test/http/requestBuilder.test.ts
+++ b/packages/core/test/http/requestBuilder.test.ts
@@ -496,10 +496,31 @@ describe('test default request builder behavior with succesful responses', () =>
     const { result } = await reqBuilder.callAsText();
     expect(result).toEqual('');
   });
+  it('should test response with whitespace content textual types', async () => {
+    const reqBuilder = customRequestBuilder({
+      statusCode: 204,
+      body: '  ',
+      headers: {},
+    });
+    const { result } = await reqBuilder.callAsText();
+    expect(result).toEqual('  ');
+  });
   it('should test response with no content string cases', async () => {
     const reqBuilder = customRequestBuilder({
       statusCode: 204,
       body: '',
+      headers: {},
+    });
+    const nullableString = await reqBuilder.callAsJson(nullable(string()));
+    expect(nullableString.result).toEqual(null);
+
+    const optionalString = await reqBuilder.callAsJson(optional(string()));
+    expect(optionalString.result).toEqual(undefined);
+  });
+  it('should test response with whitespace content string cases', async () => {
+    const reqBuilder = customRequestBuilder({
+      statusCode: 204,
+      body: '  ',
       headers: {},
     });
     const nullableString = await reqBuilder.callAsJson(nullable(string()));
@@ -520,10 +541,38 @@ describe('test default request builder behavior with succesful responses', () =>
     const optionalString = await reqBuilder.callAsJson(optional(boolean()));
     expect(optionalString.result).toEqual(undefined);
   });
+  it('should test response with whitespace content boolean cases', async () => {
+    const reqBuilder = customRequestBuilder({
+      statusCode: 204,
+      body: '  ',
+      headers: {},
+    });
+    const nullableString = await reqBuilder.callAsJson(nullable(boolean()));
+    expect(nullableString.result).toEqual(null);
+
+    const optionalString = await reqBuilder.callAsJson(optional(boolean()));
+    expect(optionalString.result).toEqual(undefined);
+  });
   it('should test response with no content object cases', async () => {
     const reqBuilder = customRequestBuilder({
       statusCode: 204,
       body: '',
+      headers: {},
+    });
+    const nullableString = await reqBuilder.callAsJson(
+      nullable(employeeSchema)
+    );
+    expect(nullableString.result).toEqual(null);
+
+    const optionalString = await reqBuilder.callAsJson(
+      optional(employeeSchema)
+    );
+    expect(optionalString.result).toEqual(undefined);
+  });
+  it('should test response with whitespace content object cases', async () => {
+    const reqBuilder = customRequestBuilder({
+      statusCode: 204,
+      body: '  ',
       headers: {},
     });
     const nullableString = await reqBuilder.callAsJson(


### PR DESCRIPTION
## What
This PR adds complete support for returning nullable response types using the nullability check using the provided schema to set the response types as nullable when content is missing.

## Why
Previously response handler was throwing an exception when a response with no content is received.

Closes #180 