### PR TITLE
fix(response-validation): request builder schema validation and numeric value handling issues

### DIFF
--- a/packages/core-interfaces/src/httpClient.ts
+++ b/packages/core-interfaces/src/httpClient.ts
@@ -1,0 +1,15 @@
+import { HttpRequest, RequestOptions } from './httpRequest';
+import { HttpResponse } from './httpResponse';
+
+/**
+ * Interface defining the contract for an HTTP client.
+ * Implementations of this interface should handle making HTTP requests
+ * and returning promises that resolve to HTTP responses.
+ * @param request The HTTP request to be sent.
+ * @param requestOptions Optional additional options for the request.
+ * @returns A promise that resolves to an HTTP response.
+ */
+export type HttpClientInterface = (
+  request: HttpRequest,
+  requestOptions?: RequestOptions
+) => Promise<HttpResponse>;

--- a/packages/core-interfaces/src/index.ts
+++ b/packages/core-interfaces/src/index.ts
@@ -1,6 +1,7 @@
 export * from './apiResponse';
 export * from './authentication';
 export * from './httpContext';
+export * from './httpClient';
 export * from './httpInterceptor';
 export * from './httpRequest';
 export * from './httpResponse';

--- a/packages/core/src/http/requestBuilder.ts
+++ b/packages/core/src/http/requestBuilder.ts
@@ -674,9 +674,9 @@ function mergePath(left: string, right?: string): string {
     return left;
   }
   // remove all occurances of `/` (if any) from the end of left path
-  left = left.replace(new RegExp(`/+$`), '');
+  left = left.replace('/', ' ').trimEnd().replace(' ', '/');
   // remove all occurances of `/` (if any) from the start of right sub-path
-  right = right.replace(new RegExp(`^/+`), '');
+  right = right.replace('/', ' ').trimStart().replace(' ', '/');
 
   return `${left}/${right}`;
 }

--- a/packages/core/src/http/requestBuilder.ts
+++ b/packages/core/src/http/requestBuilder.ts
@@ -673,15 +673,14 @@ function mergePath(left: string, right?: string): string {
   if (!right || right === '') {
     return left;
   }
+  // remove all occurances of `/` (if any) from the end of left path
+  left = left.replace(new RegExp(`/+$`), '');
+  // remove all occurances of `/` (if any) from the start of right sub-path
+  right = right.replace(new RegExp(`^/+`), '');
 
-  if (left[left.length - 1] === '/' && right[0] === '/') {
-    return left + right.substr(1);
-  } else if (left[left.length - 1] === '/' || right[0] === '/') {
-    return left + right;
-  } else {
-    return `${left}/${right}`;
-  }
+  return `${left}/${right}`;
 }
+
 function parseJsonResult<T>(schema: Schema<T, any>, res: ApiResponse<void>): T {
   if (typeof res.body !== 'string') {
     throw new Error(
@@ -707,6 +706,7 @@ function parseJsonResult<T>(schema: Schema<T, any>, res: ApiResponse<void>): T {
     new ResponseValidationError(res, errors);
   return validateJson(schema, parsed, (errors) => resInvalidErr(errors));
 }
+
 function validateJson<T>(
   schema: Schema<T, any>,
   value: any,

--- a/packages/core/test/http/requestBuilder.test.ts
+++ b/packages/core/test/http/requestBuilder.test.ts
@@ -1,11 +1,11 @@
 import {
-  HttpClientInterface,
   RequestBuilder,
   createRequestBuilderFactory,
   skipEncode,
 } from '../../src/http/requestBuilder';
 import {
   AuthenticatorInterface,
+  HttpClientInterface,
   HttpMethod,
   HttpRequest,
   HttpResponse,


### PR DESCRIPTION
This PR adds the following changes:

- Sending a primitive value as body in requests
- Receiving a string response without validation as JSON
- Empty response body handling
- Moved HttpClientInterface from requestBuilder to packages/core-interfaces/src/httpClient.ts. So it can used further in other packages in the future