### PR TITLE
fix(schema): adds support of selecting schema without discriminator fields in discriminatedSchema

### DIFF
--- a/packages/schema/src/types/discriminatedObject.ts
+++ b/packages/schema/src/types/discriminatedObject.ts
@@ -23,7 +23,7 @@ export function discriminatedObject<
   const selectSchemaWithDisc = (
     value: unknown,
     discriminatorProp: string | TDiscrimProp | TDiscrimMappedProp,
-    isAttr: boolean
+    isAttr?: boolean
   ) => {
     if (
       typeof value === 'object' &&
@@ -51,8 +51,8 @@ export function discriminatedObject<
   const selectSchema = (
     value: unknown,
     discriminatorProp: string | TDiscrimProp | TDiscrimMappedProp,
-    checker: (schema: TSchema) => SchemaValidationError[],
-    isAttr: boolean = false
+    validater: (schema: TSchema) => SchemaValidationError[],
+    isAttr?: boolean
   ) => {
     const schema = selectSchemaWithDisc(value, discriminatorProp, isAttr);
     if (typeof schema !== 'undefined') {
@@ -60,7 +60,7 @@ export function discriminatedObject<
     }
     // Try checking with discriminator matching
     for (const key in allSchemas) {
-      if (checker(allSchemas[key]).length === 0) {
+      if (validater(allSchemas[key]).length === 0) {
         return allSchemas[key];
       }
     }

--- a/packages/schema/src/types/object.ts
+++ b/packages/schema/src/types/object.ts
@@ -9,6 +9,7 @@ import { OptionalizeObject } from '../typeUtils';
 import {
   isOptional,
   isOptionalNullable,
+  isOptionalOrNullableType,
   literalToString,
   objectEntries,
   objectKeyEncode,
@@ -377,10 +378,7 @@ function validateValueObject({
             ctxt.createChild(propTypePrefix + key, valueObject[key], schema)
           )
         );
-      } else if (
-        !schema.type().startsWith('Optional<') &&
-        !schema.type().startsWith('Nullable<')
-      ) {
+      } else if (!isOptionalOrNullableType(schema.type())) {
         // Add to missing keys if it is not an optional property
         missingProps.add(key);
       }

--- a/packages/schema/src/types/object.ts
+++ b/packages/schema/src/types/object.ts
@@ -377,7 +377,10 @@ function validateValueObject({
             ctxt.createChild(propTypePrefix + key, valueObject[key], schema)
           )
         );
-      } else if (schema.type().indexOf('Optional<') !== 0) {
+      } else if (
+        !schema.type().startsWith('Optional<') &&
+        !schema.type().startsWith('Nullable<')
+      ) {
         // Add to missing keys if it is not an optional property
         missingProps.add(key);
       }

--- a/packages/schema/src/utils.ts
+++ b/packages/schema/src/utils.ts
@@ -161,9 +161,16 @@ export function isOptional(type: string, value: unknown): boolean {
 }
 
 export function isOptionalNullable(type: string, value: unknown): boolean {
+  return isOptionalAndNullableType(type) && isNullOrMissing(value);
+}
+
+export function isOptionalAndNullableType(type: string): boolean {
   return (
-    (type.startsWith('Optional<Nullable<') ||
-      type.startsWith('Nullable<Optional<')) &&
-    isNullOrMissing(value)
+    type.startsWith('Optional<Nullable<') ||
+    type.startsWith('Nullable<Optional<')
   );
+}
+
+export function isOptionalOrNullableType(type: string): boolean {
+  return type.startsWith('Optional<') || type.startsWith('Nullable<');
 }


### PR DESCRIPTION
This PR adds the following changes:
- adds the support for selecting an internal schema even if discriminator field is absent
- adds the optional and nullable support in object schema