### PR TITLE
feat: support object and unkown header parameters

### DIFF
--- a/packages/core/src/http/requestBuilder.ts
+++ b/packages/core/src/http/requestBuilder.ts
@@ -112,7 +112,7 @@ export interface RequestBuilder<BaseUrlParamType, AuthParams> {
   acceptJson(): void;
   accept(acceptHeaderValue: string): void;
   contentType(contentTypeHeaderValue: string): void;
-  header(name: string, value?: string | boolean | number | bigint | null): void;
+  header(name: string, value?: unknown): void;
   headers(headersToMerge: Record<string, string>): void;
   query(
     name: string,
@@ -271,14 +271,16 @@ export class DefaultRequestBuilder<BaseUrlParamType, AuthParams>
   public contentType(contentTypeHeaderValue: string): void {
     this._contentType = contentTypeHeaderValue;
   }
-  public header(
-    name: string,
-    value?: string | boolean | number | bigint | null
-  ): void {
+  public header(name: string, value?: unknown): void {
     if (value === null || typeof value === 'undefined') {
       return;
     }
-    setHeader(this._headers, name, value.toString());
+    if (typeof value === 'object') {
+      setHeader(this._headers, name, JSON.stringify(value));
+      return;
+    }
+    // String() is used to convert boolean, number, bigint, or unknown types
+    setHeader(this._headers, name, String(value));
   }
   public headers(headersToMerge: Record<string, string>): void {
     mergeHeaders(this._headers, headersToMerge);

--- a/packages/core/test/http/requestBuilder.test.ts
+++ b/packages/core/test/http/requestBuilder.test.ts
@@ -60,30 +60,6 @@ describe('test default request builder behavior with succesful responses', () =>
     retryConfig
   );
 
-  it('should test request builder configured with all kind of headers', async () => {
-    const reqBuilder = defaultRequestBuilder('GET', '/test/requestBuilder');
-    reqBuilder.baseUrl('default');
-    reqBuilder.header('test-header-missing1');
-    reqBuilder.header('test-header-missing2', null);
-    reqBuilder.header('test-header1', 'test-value\'"\n1');
-    reqBuilder.header('test-header2', true);
-    reqBuilder.header('test-header3', false);
-    reqBuilder.header('test-header4', 12345);
-    reqBuilder.header('test-header5', BigInt(12345));
-    reqBuilder.header('test-header6', { key: 'v a l u e' });
-    reqBuilder.header('test-header7', Symbol());
-
-    const apiResponse = await reqBuilder.callAsText();
-    expect(apiResponse.request.headers).toEqual({
-      'test-header1': 'test-value\'"\n1',
-      'test-header2': 'true',
-      'test-header3': 'false',
-      'test-header4': '12345',
-      'test-header5': '12345',
-      'test-header6': '{"key":"v a l u e"}',
-      'test-header7': 'Symbol()',
-    });
-  });
   it('should test request builder configured with text request body and text response body', async () => {
     const expectedRequest: HttpRequest = {
       method: 'GET',
@@ -585,6 +561,30 @@ describe('test default request builder behavior with succesful responses', () =>
       optional(employeeSchema)
     );
     expect(optionalString.result).toEqual(undefined);
+  });
+  it('should test request builder configured with all kind of headers', async () => {
+    const reqBuilder = defaultRequestBuilder('GET', '/test/requestBuilder');
+    reqBuilder.baseUrl('default');
+    reqBuilder.header('test-header-missing1');
+    reqBuilder.header('test-header-missing2', null);
+    reqBuilder.header('test-header1', 'test-value\'"\n1');
+    reqBuilder.header('test-header2', true);
+    reqBuilder.header('test-header3', false);
+    reqBuilder.header('test-header4', 12345);
+    reqBuilder.header('test-header5', BigInt(12345));
+    reqBuilder.header('test-header6', { key: 'v a l u e' });
+    reqBuilder.header('test-header7', Symbol());
+
+    const apiResponse = await reqBuilder.callAsText();
+    expect(apiResponse.request.headers).toEqual({
+      'test-header1': 'test-value\'"\n1',
+      'test-header2': 'true',
+      'test-header3': 'false',
+      'test-header4': '12345',
+      'test-header5': '12345',
+      'test-header6': '{"key":"v a l u e"}',
+      'test-header7': 'Symbol()',
+    });
   });
 
   function customRequestBuilder(

--- a/packages/core/test/http/requestBuilder.test.ts
+++ b/packages/core/test/http/requestBuilder.test.ts
@@ -60,6 +60,30 @@ describe('test default request builder behavior with succesful responses', () =>
     retryConfig
   );
 
+  it('should test request builder configured with all kind of headers', async () => {
+    const reqBuilder = defaultRequestBuilder('GET', '/test/requestBuilder');
+    reqBuilder.baseUrl('default');
+    reqBuilder.header('test-header-missing1');
+    reqBuilder.header('test-header-missing2', null);
+    reqBuilder.header('test-header1', 'test-value\'"\n1');
+    reqBuilder.header('test-header2', true);
+    reqBuilder.header('test-header3', false);
+    reqBuilder.header('test-header4', 12345);
+    reqBuilder.header('test-header5', BigInt(12345));
+    reqBuilder.header('test-header6', { key: 'v a l u e' });
+    reqBuilder.header('test-header7', Symbol());
+
+    const apiResponse = await reqBuilder.callAsText();
+    expect(apiResponse.request.headers).toEqual({
+      'test-header1': 'test-value\'"\n1',
+      'test-header2': 'true',
+      'test-header3': 'false',
+      'test-header4': '12345',
+      'test-header5': '12345',
+      'test-header6': '{"key":"v a l u e"}',
+      'test-header7': 'Symbol()',
+    });
+  });
   it('should test request builder configured with text request body and text response body', async () => {
     const expectedRequest: HttpRequest = {
       method: 'GET',


### PR DESCRIPTION
This PR adds the support of sending the header parameter of object and unknown types along with the already supported types.

Closes #185 