### PR TITLE
feat(additional-properties): adds typed expando object schema

### DIFF
--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -210,8 +210,8 @@ function createSchemaContextCreator(
     createSchemaContextCreator({
       value,
       type: childSchema.type(),
-      branch: [...currentContext.branch, value],
-      path: [...currentContext.path, key],
+      branch: currentContext.branch.concat(value),
+      path: currentContext.path.concat(key),
       strictValidation: currentContext.strictValidation,
     });
 

--- a/packages/schema/src/types/object.ts
+++ b/packages/schema/src/types/object.ts
@@ -256,11 +256,8 @@ function validateObjectBeforeMapXml(
       [key: string]: unknown;
     };
     const { $: attrs, ...elements } = valueObject;
-    const attributes = attrs ?? {};
 
-    // Validate all known elements and attributes using the schema
-
-    return validateValueObject({
+    let validationObj = {
       validationMethod: 'validateBeforeMapXml',
       propTypeName: 'child elements',
       propTypePrefix: 'element',
@@ -271,20 +268,21 @@ function validateObjectBeforeMapXml(
       ctxt,
       skipAdditionalPropValidation,
       mapAdditionalProps,
-    }).concat(
-      validateValueObject({
-        validationMethod: 'validateBeforeMapXml',
-        propTypeName: 'attributes',
-        propTypePrefix: '@',
-        valueTypeName: 'element',
-        propMapping: attributesToProps,
-        objectSchema,
-        valueObject: attributes,
-        ctxt,
-        skipAdditionalPropValidation,
-        mapAdditionalProps,
-      })
-    );
+    };
+    // Validate all known elements using the schema
+    const elementErrors = validateValueObject(validationObj);
+
+    validationObj = {
+      ...validationObj,
+      propTypeName: 'attributes',
+      propTypePrefix: '@',
+      propMapping: attributesToProps,
+      valueObject: attrs ?? {},
+    };
+    // Validate all known attributes using the schema
+    const attributesErrors = validateValueObject(validationObj);
+
+    return elementErrors.concat(attributesErrors);
   };
 }
 
@@ -388,10 +386,7 @@ function validateValueObject({
   skipAdditionalPropValidation,
   mapAdditionalProps,
 }: {
-  validationMethod:
-    | 'validateBeforeMap'
-    | 'validateBeforeUnmap'
-    | 'validateBeforeMapXml';
+  validationMethod: string;
   propTypeName: string;
   propTypePrefix: string;
   valueTypeName: string;

--- a/packages/schema/src/types/object.ts
+++ b/packages/schema/src/types/object.ts
@@ -401,14 +401,6 @@ function validateValueObject(
     mapAdditionalProps[0] in valueObject
   ) {
     Object.entries(valueObject[mapAdditionalProps[0]]).forEach(([key, _]) => {
-      if (key.trim().length === 0) {
-        ctxt
-          .fail(
-            'The additional property key should not be empty or whitespace.'
-          )
-          .forEach((e) => errors.push(e));
-      }
-
       if (Object.prototype.hasOwnProperty.call(objectSchema, key)) {
         ctxt
           .fail(

--- a/packages/schema/src/types/object.ts
+++ b/packages/schema/src/types/object.ts
@@ -260,30 +260,30 @@ function validateObjectBeforeMapXml(
 
     // Validate all known elements and attributes using the schema
 
-    return validateValueObject(
-      'validateBeforeMapXml',
-      'child elements',
-      'element',
-      'element',
-      elementsToProps,
+    return validateValueObject({
+      validationMethod: 'validateBeforeMapXml',
+      propTypeName: 'child elements',
+      propTypePrefix: 'element',
+      valueTypeName: 'element',
+      propMapping: elementsToProps,
       objectSchema,
-      elements,
+      valueObject: elements,
       ctxt,
       skipAdditionalPropValidation,
-      mapAdditionalProps
-    ).concat(
-      validateValueObject(
-        'validateBeforeMapXml',
-        'attributes',
-        '@',
-        'element',
-        attributesToProps,
+      mapAdditionalProps,
+    }).concat(
+      validateValueObject({
+        validationMethod: 'validateBeforeMapXml',
+        propTypeName: 'attributes',
+        propTypePrefix: '@',
+        valueTypeName: 'element',
+        propMapping: attributesToProps,
         objectSchema,
-        attributes,
+        valueObject: attributes,
         ctxt,
         skipAdditionalPropValidation,
-        mapAdditionalProps
-      )
+        mapAdditionalProps,
+      })
     );
   };
 }
@@ -376,21 +376,32 @@ function unmapObjectToXml(
   };
 }
 
-function validateValueObject(
+function validateValueObject({
+  validationMethod,
+  propTypeName,
+  propTypePrefix,
+  valueTypeName,
+  propMapping,
+  objectSchema,
+  valueObject,
+  ctxt,
+  skipAdditionalPropValidation,
+  mapAdditionalProps,
+}: {
   validationMethod:
     | 'validateBeforeMap'
     | 'validateBeforeUnmap'
-    | 'validateBeforeMapXml',
-  propTypeName: string,
-  propTypePrefix: string,
-  valueTypeName: string,
-  propMapping: Record<string, string>,
-  objectSchema: AnyObjectSchema,
-  valueObject: { [key: string]: any },
-  ctxt: SchemaContextCreator,
-  skipAdditionalPropValidation: boolean,
-  mapAdditionalProps: boolean | [string, Schema<any, any>]
-) {
+    | 'validateBeforeMapXml';
+  propTypeName: string;
+  propTypePrefix: string;
+  valueTypeName: string;
+  propMapping: Record<string, string>;
+  objectSchema: AnyObjectSchema;
+  valueObject: { [key: string]: any };
+  ctxt: SchemaContextCreator;
+  skipAdditionalPropValidation: boolean;
+  mapAdditionalProps: boolean | [string, Schema<any, any>];
+}) {
   const errors: SchemaValidationError[] = [];
   const missingProps: Set<string> = new Set();
   const conflictingProps: Set<string> = new Set();
@@ -408,6 +419,7 @@ function validateValueObject(
     }
   }
 
+  // Create validation errors for conflicting additional properties keys
   addErrorsIfAny(
     conflictingProps,
     (names) =>
@@ -499,7 +511,7 @@ function validateObject(
   skipAdditionalPropValidation: boolean,
   mapAdditionalProps: boolean | [string, Schema<any, any>]
 ) {
-  const propsMapping = getPropMappingForObjectSchema(objectSchema);
+  const propMapping = getPropMappingForObjectSchema(objectSchema);
   return (value: unknown, ctxt: SchemaContextCreator) => {
     if (typeof value !== 'object' || value === null) {
       return ctxt.fail();
@@ -511,18 +523,18 @@ function validateObject(
         }' but found 'Array<${typeof value}>'.`
       );
     }
-    return validateValueObject(
+    return validateValueObject({
       validationMethod,
-      'properties',
-      '',
-      'object',
-      propsMapping,
+      propTypeName: 'properties',
+      propTypePrefix: '',
+      valueTypeName: 'object',
+      propMapping,
       objectSchema,
-      value as Record<string, unknown>,
+      valueObject: value as Record<string, any>,
       ctxt,
       skipAdditionalPropValidation,
-      mapAdditionalProps
-    );
+      mapAdditionalProps,
+    });
   };
 }
 

--- a/packages/schema/src/types/object.ts
+++ b/packages/schema/src/types/object.ts
@@ -5,6 +5,7 @@ import {
   SchemaType,
   SchemaValidationError,
   validateAndMap,
+  validateAndUnmap,
 } from '../schema';
 import { OptionalizeObject } from '../typeUtils';
 import {
@@ -573,7 +574,10 @@ function extractAdditionalProperties(
   }
 
   Object.entries(objectValue).forEach(([k, v]) => {
-    const mappingResult = validateAndMap({ [k]: v }, mapAdditionalProps[1]);
+    const testValue = { [k]: v };
+    const mappingResult = isUnmaping
+      ? validateAndUnmap(testValue, mapAdditionalProps[1])
+      : validateAndMap(testValue, mapAdditionalProps[1]);
     if (mappingResult.errors) {
       return;
     }

--- a/packages/schema/src/types/object.ts
+++ b/packages/schema/src/types/object.ts
@@ -288,10 +288,10 @@ function validateObjectBeforeMapXml(
 
 function mapObjectFromXml(
   xmlObjectSchema: XmlObjectSchema,
-  allowAdditionalProps: boolean | [string, Schema<any, any>]
+  mapAdditionalProps: boolean | [string, Schema<any, any>]
 ) {
   const { elementsSchema, attributesSchema } = xmlObjectSchema;
-  const mapElements = mapObject(elementsSchema, 'mapXml', allowAdditionalProps);
+  const mapElements = mapObject(elementsSchema, 'mapXml', mapAdditionalProps);
   const mapAttributes = mapObject(
     attributesSchema,
     'mapXml',
@@ -317,7 +317,7 @@ function mapObjectFromXml(
       ...mapElements(elements, ctxt),
     };
 
-    if (allowAdditionalProps) {
+    if (mapAdditionalProps) {
       // Omit known attributes and copy the rest as additional attributes.
       const additionalAttrs = omitKeysFromObject(attributes, attributeKeys);
       if (Object.keys(additionalAttrs).length > 0) {
@@ -332,14 +332,10 @@ function mapObjectFromXml(
 
 function unmapObjectToXml(
   xmlObjectSchema: XmlObjectSchema,
-  allowAdditionalProps: boolean | [string, Schema<any, any>]
+  mapAdditionalProps: boolean | [string, Schema<any, any>]
 ) {
   const { elementsSchema, attributesSchema } = xmlObjectSchema;
-  const mapElements = mapObject(
-    elementsSchema,
-    'unmapXml',
-    allowAdditionalProps
-  );
+  const mapElements = mapObject(elementsSchema, 'unmapXml', mapAdditionalProps);
   const mapAttributes = mapObject(
     attributesSchema,
     'unmapXml',
@@ -347,7 +343,7 @@ function unmapObjectToXml(
   );
 
   // These are later used to omit attribute props from the value object so that they
-  // do not get mapped during element mapping, if the allowAdditionalProps is true.
+  // do not get mapped during element mapping, if the mapAdditionalProps is set.
   const attributeKeys = objectEntries(attributesSchema).map(
     ([_, [name]]) => name
   );
@@ -363,7 +359,7 @@ function unmapObjectToXml(
     const additionalAttributes =
       typeof attributes === 'object' &&
       attributes !== null &&
-      allowAdditionalProps
+      mapAdditionalProps
         ? attributes
         : {};
 

--- a/packages/schema/src/types/object.ts
+++ b/packages/schema/src/types/object.ts
@@ -17,6 +17,8 @@ import {
   objectKeyEncode,
   omitKeysFromObject,
 } from '../utils';
+import { dict } from './dict';
+import { optional } from './optional';
 
 type AnyObjectSchema = Record<
   string,
@@ -69,8 +71,8 @@ export interface ExtendedObjectSchema<
   K extends string,
   U
 > extends Schema<
-    ObjectType<T> & { [key in K]?: U },
-    MappedObjectType<T> & { [key in K]?: U }
+    ObjectType<T> & { [key in K]?: Record<string, U> },
+    MappedObjectType<T> & { [key in K]?: Record<string, U> }
   > {
   readonly objectSchema: T;
 }
@@ -120,9 +122,13 @@ export function typedExpandoObject<
   S extends Schema<any, any>
 >(
   objectSchema: T,
-  additionalPropSchema: [K, S]
+  additionalPropertyKey: K,
+  additionalPropertySchema: S
 ): ExtendedObjectSchema<V, T, K, SchemaType<S>> {
-  return internalObject(objectSchema, true, additionalPropSchema);
+  return internalObject(objectSchema, true, [
+    additionalPropertyKey,
+    optional(dict(additionalPropertySchema)),
+  ]);
 }
 
 /**

--- a/packages/schema/test/types/expandoObject.test.ts
+++ b/packages/schema/test/types/expandoObject.test.ts
@@ -464,7 +464,7 @@ describe('Expando Object', () => {
                 "id": "John Smith",
               },
             ],
-            "message": "An additional property key, 'user_age' conflicts with one of the model's properties.
+            "message": "Some keys in additional properties are conflicting with the keys in object: \\"user_age\\".
 
         Given value: {\\"id\\":\\"John Smith\\",\\"age\\":50,\\"additionalProps\\":{\\"number1\\":123,\\"number2\\":123.2,\\"user_age\\":52}}
         Type: 'object'

--- a/packages/schema/test/types/expandoObject.test.ts
+++ b/packages/schema/test/types/expandoObject.test.ts
@@ -291,7 +291,7 @@ describe('Expando Object', () => {
   });
 
   describe('Unmapping', () => {
-    it('AdditionalProperties: should map with additional properties', () => {
+    it('AdditionalProperties: should unmap with additional properties', () => {
       const input = {
         id: 'John Smith',
         age: 50, // takes precedence over additionalProps[user_age]
@@ -311,7 +311,7 @@ describe('Expando Object', () => {
       expect((output as any).result).toStrictEqual(expected);
     });
 
-    it('AdditionalProperties: should map without additional properties', () => {
+    it('AdditionalProperties: should unmap without additional properties', () => {
       const input = {
         id: 'John Smith',
         age: 50,
@@ -325,7 +325,7 @@ describe('Expando Object', () => {
       expect((output as any).result).toStrictEqual(expected);
     });
 
-    it('AdditionalProperties: should map with object typed additional properties', () => {
+    it('AdditionalProperties: should unmap with object typed additional properties', () => {
       const input = {
         id: 'John Smith',
         age: 50,
@@ -349,7 +349,7 @@ describe('Expando Object', () => {
       expect((output as any).result).toStrictEqual(expected);
     });
 
-    it('AdditionalProperties: should map with anyOf typed additional properties', () => {
+    it('AdditionalProperties: should unmap with anyOf typed additional properties', () => {
       const input = {
         id: 'John Smith',
         age: 50,
@@ -375,7 +375,27 @@ describe('Expando Object', () => {
       expect((output as any).result).toStrictEqual(expected);
     });
 
-    it('should map valid object', () => {
+    it('AdditionalProperties: should unmap with empty or blank additional property keys', () => {
+      const input = {
+        id: 'John Smith',
+        age: 50,
+        additionalProps: {
+          '  ': 123.2,
+          '': 52,
+        },
+      };
+      const output = validateAndUnmap(input, userSchemaWithAdditionalNumbers);
+      const expected = {
+        user_id: 'John Smith',
+        user_age: 50,
+        '  ': 123.2,
+        '': 52,
+      };
+      expect(output.errors).toBeFalsy();
+      expect((output as any).result).toStrictEqual(expected);
+    });
+
+    it('should unmap valid object', () => {
       const input = {
         id: 'John Smith',
         age: 50,
@@ -389,7 +409,7 @@ describe('Expando Object', () => {
       expect((output as any).result).toStrictEqual(expected);
     });
 
-    it('should map object with optional properties', () => {
+    it('should unmap object with optional properties', () => {
       const addressSchema = expandoObject({
         address1: ['address1', string()],
         address2: ['address2', optional(string())],
@@ -402,7 +422,7 @@ describe('Expando Object', () => {
       expect((output as any).result).toStrictEqual(input);
     });
 
-    it('should map valid object with additional properties', () => {
+    it('should unmap valid object with additional properties', () => {
       const input = {
         id: 'John Smith',
         age: 50,
@@ -456,77 +476,6 @@ describe('Expando Object', () => {
                 "number1": 123,
                 "number2": 123.2,
                 "user_age": 52,
-              },
-              "age": 50,
-              "id": "John Smith",
-            },
-          },
-        ]
-      `);
-    });
-
-    it('AdditionalProperties: should fail with empty or blank additional property keys', () => {
-      const input = {
-        id: 'John Smith',
-        age: 50,
-        additionalProps: {
-          '  ': 123.2,
-          '': 52,
-        },
-      };
-      const output = validateAndUnmap(input, userSchemaWithAdditionalNumbers);
-      expect(output.errors).toHaveLength(2);
-      expect(output.errors).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "branch": Array [
-              Object {
-                "additionalProps": Object {
-                  "": 52,
-                  "  ": 123.2,
-                },
-                "age": 50,
-                "id": "John Smith",
-              },
-            ],
-            "message": "The additional property key should not be empty or whitespace.
-
-        Given value: {\\"id\\":\\"John Smith\\",\\"age\\":50,\\"additionalProps\\":{\\"  \\":123.2,\\"\\":52}}
-        Type: 'object'
-        Expected type: 'Object<{id,age,...}>'",
-            "path": Array [],
-            "type": "Object<{id,age,...}>",
-            "value": Object {
-              "additionalProps": Object {
-                "": 52,
-                "  ": 123.2,
-              },
-              "age": 50,
-              "id": "John Smith",
-            },
-          },
-          Object {
-            "branch": Array [
-              Object {
-                "additionalProps": Object {
-                  "": 52,
-                  "  ": 123.2,
-                },
-                "age": 50,
-                "id": "John Smith",
-              },
-            ],
-            "message": "The additional property key should not be empty or whitespace.
-
-        Given value: {\\"id\\":\\"John Smith\\",\\"age\\":50,\\"additionalProps\\":{\\"  \\":123.2,\\"\\":52}}
-        Type: 'object'
-        Expected type: 'Object<{id,age,...}>'",
-            "path": Array [],
-            "type": "Object<{id,age,...}>",
-            "value": Object {
-              "additionalProps": Object {
-                "": 52,
-                "  ": 123.2,
               },
               "age": 50,
               "id": "John Smith",

--- a/packages/schema/test/types/expandoObject.test.ts
+++ b/packages/schema/test/types/expandoObject.test.ts
@@ -8,7 +8,6 @@ import {
   validateAndMap,
   validateAndUnmap,
   typedExpandoObject,
-  dict,
   object,
   anyOf,
 } from '../../src';
@@ -24,7 +23,8 @@ describe('Expando Object', () => {
       id: ['user_id', string()],
       age: ['user_age', number()],
     },
-    ['additionalProps', optional(dict(number()))]
+    'additionalProps',
+    number()
   );
 
   const workSchema = object({
@@ -37,7 +37,8 @@ describe('Expando Object', () => {
       id: ['user_id', string()],
       age: ['user_age', number()],
     },
-    ['additionalProps', optional(dict(workSchema))]
+    'additionalProps',
+    workSchema
   );
 
   const userSchemaWithAdditionalAnyOf = typedExpandoObject(
@@ -45,7 +46,8 @@ describe('Expando Object', () => {
       id: ['user_id', string()],
       age: ['user_age', number()],
     },
-    ['additionalProps', optional(dict(anyOf([workSchema, number()])))]
+    'additionalProps',
+    anyOf([workSchema, number()])
   );
 
   describe('Mapping', () => {


### PR DESCRIPTION
This PR adds a new schema for validating, mapping and un-mapping additional properties in an object. It will also validate and skip the additional properties that do not match the specified type while mapping. While the un-mapping step will fail if the additional properties key matches one of the objects original keys.

Closes #192 