### PR TITLE
fix(workflow): correct workflow file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         run: yarn check-style
         
       - name: Upload coverage reports
-        if: ${{ matrix.node == "19.x" && github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: paambaati/codeclimate-action@v3.0.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.TEST_REPORTER_ID }}


### PR DESCRIPTION
Adjusted the GitHub Actions workflow file condition to remove the node version 19.x condition. This resolves pipeline errors.