### PR TITLE
fix(logger): masking headers flow is changing values of request headers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apimatic/core",
   "author": "APIMatic Ltd.",
-  "version": "0.10.18",
+  "version": "0.10.17",
   "license": "MIT",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apimatic/core",
   "author": "APIMatic Ltd.",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "license": "MIT",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/core/test/http/apiLogger.test.ts
+++ b/packages/core/test/http/apiLogger.test.ts
@@ -133,7 +133,7 @@ describe('Test APILogger with Request ConsoleLogging', () => {
 
     const expectedConsoleLogs = [
       'info: Request GET https://apimatic.hopto.org:3000/test/requestBuilder content-type',
-      'info: Request headers {"Content-type":"content-type","Content-length":"Content-length","Authorization":"Basic WmVlc2hhbjo5OQ=="}',
+      'info: Request headers {"Content-type":"content-type","Content-length":"Content-length","Authorization":"Basic dGVzdF91c2VyOnRlc3RfcGFzc18xMjM="}',
     ];
 
     await mockClient(loggingOpts);
@@ -151,7 +151,7 @@ describe('Test APILogger with Request ConsoleLogging', () => {
 
     const expectedConsoleLogs = [
       'info: Request GET https://apimatic.hopto.org:3000/test/requestBuilder content-type',
-      'info: Request headers {"Content-type":"content-type","Content-length":"Content-length","Authorization":"Basic WmVlc2hhbjo5OQ=="}',
+      'info: Request headers {"Content-type":"content-type","Content-length":"Content-length","Authorization":"Basic dGVzdF91c2VyOnRlc3RfcGFzc18xMjM="}',
     ];
 
     await mockClient(loggingOpts);
@@ -321,8 +321,8 @@ function mockRequest(): HttpRequest {
       'Content-length': 'Content-length',
     },
     auth: {
-      username: 'Zeeshan',
-      password: '99',
+      username: 'test_user',
+      password: 'test_pass_123',
     },
     body: {
       type: 'text',

--- a/packages/core/test/http/apiLogger.test.ts
+++ b/packages/core/test/http/apiLogger.test.ts
@@ -133,7 +133,7 @@ describe('Test APILogger with Request ConsoleLogging', () => {
 
     const expectedConsoleLogs = [
       'info: Request GET https://apimatic.hopto.org:3000/test/requestBuilder content-type',
-      'info: Request headers {"Content-type":"content-type","Content-length":"Content-length","Authorization":"Bearer EAAAEFZ2r-rqsEBBB0s2rh210e18mspf4dzga"}',
+      'info: Request headers {"Content-type":"content-type","Content-length":"Content-length","Authorization":"Basic WmVlc2hhbjo5OQ=="}',
     ];
 
     await mockClient(loggingOpts);
@@ -151,7 +151,7 @@ describe('Test APILogger with Request ConsoleLogging', () => {
 
     const expectedConsoleLogs = [
       'info: Request GET https://apimatic.hopto.org:3000/test/requestBuilder content-type',
-      'info: Request headers {"Content-type":"content-type","Content-length":"Content-length","Authorization":"Bearer EAAAEFZ2r-rqsEBBB0s2rh210e18mspf4dzga"}',
+      'info: Request headers {"Content-type":"content-type","Content-length":"Content-length","Authorization":"Basic WmVlc2hhbjo5OQ=="}',
     ];
 
     await mockClient(loggingOpts);
@@ -319,7 +319,10 @@ function mockRequest(): HttpRequest {
     headers: {
       'Content-type': 'content-type',
       'Content-length': 'Content-length',
-      Authorization: 'Bearer EAAAEFZ2r-rqsEBBB0s2rh210e18mspf4dzga',
+    },
+    auth: {
+      username: 'Zeeshan',
+      password: '99',
     },
     body: {
       type: 'text',


### PR DESCRIPTION
This PR fixes an issue where the masking headers flow was unintentionally modifying request headers. Instead of modifying request.headers directly, a cloned version is now used to ensure that the original headers remain unchanged.

**Changes:**
Cloned request.headers before applying transformations.
Ensured basic authentication header gets logged
Clone mask_headers to not directly modify request.headers

closes #225