### PR TITLE
fix(core): populate error.result for all response types

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,6 @@
   "tabWidth": 2,
   "useTabs": false,
   "semi": true,
-  "singleQuote": true,
   "trailingComma": "es5",
   "bracketSpacing": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,7 @@
   "tabWidth": 2,
   "useTabs": false,
   "semi": true,
+  "singleQuote": true,
   "trailingComma": "es5",
   "bracketSpacing": true
 }

--- a/packages/authentication-adapters/package.json
+++ b/packages/authentication-adapters/package.json
@@ -20,7 +20,7 @@
     "node": ">=14.15.0 || >=16.0.0"
   },
   "scripts": {
-    "clean": "rm -rf lib es umd tsconfig.tsbuildinfo",
+    "clean": "rimraf lib es umd tsconfig.tsbuildinfo",
     "test": "jest",
     "build": "npm run clean && tsc && rollup -c --bundleConfigAsCjs && npm run annotate:es",
     "annotate:es": "babel es --out-dir es --no-babelrc --plugins annotate-pure-calls",

--- a/packages/axios-client-adapter/package.json
+++ b/packages/axios-client-adapter/package.json
@@ -20,7 +20,7 @@
     "node": ">=14.15.0 || >=16.0.0"
   },
   "scripts": {
-    "clean": "rm -rf lib es umd tsconfig.tsbuildinfo",
+    "clean": "rimraf lib es umd tsconfig.tsbuildinfo",
     "test": "jest",
     "build": "npm run clean && tsc && rollup -c --bundleConfigAsCjs && npm run annotate:es",
     "annotate:es": "babel es --out-dir es --no-babelrc --plugins annotate-pure-calls",

--- a/packages/convert-to-stream/package.json
+++ b/packages/convert-to-stream/package.json
@@ -9,7 +9,7 @@
     "node": ">=14.15.0 || >=16.0.0"
   },
   "scripts": {
-    "clean": "rm -rf lib es umd tsconfig.tsbuildinfo",
+    "clean": "rimraf lib es umd tsconfig.tsbuildinfo",
     "test": "jest --passWithNoTests",
     "build": "npm run clean && tsc && rollup -c --bundleConfigAsCjs && npm run annotate:es",
     "annotate:es": "babel es --out-dir es --no-babelrc --plugins annotate-pure-calls",

--- a/packages/core-interfaces/package.json
+++ b/packages/core-interfaces/package.json
@@ -20,7 +20,7 @@
     "node": ">=14.15.0 || >=16.0.0"
   },
   "scripts": {
-    "clean": "rm -rf lib es umd tsconfig.tsbuildinfo",
+    "clean": "rimraf lib es umd tsconfig.tsbuildinfo",
     "test": "jest --passWithNoTests",
     "build": "npm run clean && tsc && rollup -c --bundleConfigAsCjs && npm run annotate:es",
     "annotate:es": "babel es --out-dir es --no-babelrc --plugins annotate-pure-calls",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "node": ">=14.15.0 || >=16.0.0"
   },
   "scripts": {
-    "clean": "rm -rf lib es umd tsconfig.tsbuildinfo",
+    "clean": "rimraf lib es umd tsconfig.tsbuildinfo",
     "test": "jest",
     "build": "npm run clean && tsc && rollup -c --bundleConfigAsCjs && npm run annotate:es",
     "annotate:es": "babel es --out-dir es --no-babelrc --plugins annotate-pure-calls",

--- a/packages/core/src/errors/apiError.ts
+++ b/packages/core/src/errors/apiError.ts
@@ -44,12 +44,7 @@ export class ApiError<T = {}>
         this.result = await this.parseBlobBody(this.body);
       }
     } catch (error) {
-      if (process.env.NODE_ENV !== 'production' && console) {
-        // tslint:disable-next-line:no-console
-        console.warn(
-          `Unexpected error: Could not parse HTTP response body. ${error.message}`
-        );
-      }
+      this.logParseWarning(error);
     }
   }
 
@@ -81,5 +76,14 @@ export class ApiError<T = {}>
       reader.onerror = reject;
       reader.readAsArrayBuffer(blob);
     });
+  }
+
+  private logParseWarning(error: any): void {
+    if (process.env.NODE_ENV !== 'production' && console) {
+      // tslint:disable-next-line:no-console
+      console.warn(
+        `Unexpected error: Could not parse HTTP response body. ${error.message}`
+      );
+    }
   }
 }

--- a/packages/core/src/errors/apiError.ts
+++ b/packages/core/src/errors/apiError.ts
@@ -4,6 +4,7 @@ import {
   HttpContext,
   HttpRequest,
 } from '@apimatic/core-interfaces';
+import { Readable } from 'stream';
 
 /**
  * Thrown when the HTTP status code is not okay.
@@ -29,21 +30,56 @@ export class ApiError<T = {}>
     this.statusCode = response.statusCode;
     this.headers = response.headers;
     this.body = response.body;
+  }
 
-    if (typeof response.body === 'string' && response.body !== '') {
-      const JSON = JSONBig();
-      try {
-        this.result = JSON.parse(response.body);
-      } catch (error) {
-        if (process.env.NODE_ENV !== 'production') {
-          if (console) {
-            // tslint:disable-next-line:no-console
-            console.warn(
-              `Unexpected error: Could not parse HTTP response body as JSON. ${error.message}`
-            );
-          }
-        }
+  public async setResult(): Promise<void> {
+    try {
+      if (typeof this.body === 'string' && this.body !== '') {
+        this.result = this.parseStringBody(this.body);
+      }
+      if (typeof Readable !== 'undefined' && this.body instanceof Readable) {
+        this.result = await this.parseStreamBody(this.body);
+      }
+      if (typeof Blob !== 'undefined' && this.body instanceof Blob) {
+        this.result = await this.parseBlobBody(this.body);
+      }
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production' && console) {
+        // tslint:disable-next-line:no-console
+        console.warn(
+          `Unexpected error: Could not parse HTTP response body. ${error.message}`
+        );
       }
     }
+  }
+
+  private parseStringBody(body: string): T | undefined {
+    const jsonBig = JSONBig();
+    return jsonBig.parse(body);
+  }
+
+  private async parseStreamBody(body: Readable): Promise<T | undefined> {
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of body) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const jsonString = Buffer.concat(chunks).toString();
+    return JSON.parse(jsonString);
+  }
+
+  private async parseBlobBody(body: Blob): Promise<T | undefined> {
+    const arrayBuffer = await this.blobToArrayBuffer(body);
+    const buffer = Buffer.from(arrayBuffer);
+    const jsonString = buffer.toString();
+    return JSON.parse(jsonString);
+  }
+
+  private blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+    return new Promise<ArrayBuffer>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as ArrayBuffer);
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(blob);
+    });
   }
 }

--- a/packages/core/test/errors/apiError.test.ts
+++ b/packages/core/test/errors/apiError.test.ts
@@ -1,116 +1,326 @@
 import { ApiError } from '../../src/errors/apiError';
 import { HttpRequest, HttpResponse } from '../../src/coreInterfaces';
+import { Readable } from 'stream';
 
-describe('Test API Error Instance', () => {
-  const deprecationSpy = jest.spyOn(console, 'warn');
-  test.each([
-    [
-      'test with string in response body',
-      {
-        method: 'GET',
-        url: 'url',
-        headers: { 'test-header': 'test-value' },
-        body: {
-          content: 'testBody',
-          type: 'text',
+function stringToStream(str: string) {
+  const stream = new Readable();
+  stream.push(str);
+  stream.push(null);
+  return stream;
+}
+
+function stringToBlob(str: string, type = 'application/json') {
+  return new Blob([str], { type });
+}
+
+describe('ApiError Class', () => {
+  describe('Test API Error Instance', () => {
+    const deprecationSpy = jest.spyOn(console, 'warn');
+    test.each([
+      [
+        'should set properties correctly in constructor',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: { content: 'testBody', type: 'text' },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: '',
+          headers: { 'test-header': 'test-value' },
+        } as HttpResponse,
+        undefined,
+        'production',
+        undefined,
+        'constructor',
+      ],
+      [
+        'should parse valid JSON string body',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: { content: 'testBody', type: 'text' },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: '{"foo": "bar"}',
+          headers: { 'test-header': 'test-value' },
+        } as HttpResponse,
+        { foo: 'bar' },
+        'production',
+        undefined,
+        'parse',
+      ],
+      [
+        'should leave result undefined for empty string body',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: { content: 'testBody', type: 'text' },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: '',
+          headers: { 'test-header': 'test-value' },
+        } as HttpResponse,
+        undefined,
+        'production',
+        undefined,
+        'parse',
+      ],
+      [
+        'should parse valid JSON from Readable stream body',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: { content: 'testBody', type: 'text' },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: stringToStream('{"a":1}'),
+          headers: { 'test-header': 'test-value' },
+        } as HttpResponse,
+        { a: 1 },
+        'production',
+        undefined,
+        'parse',
+      ],
+      [
+        'should leave result undefined for invalid JSON string body',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: { content: 'testBody', type: 'text' },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: '{invalid json}',
+          headers: { 'test-header': 'test-value' },
+        } as HttpResponse,
+        undefined,
+        'production',
+        undefined,
+        'parse',
+      ],
+      [
+        'should leave result undefined for invalid JSON in Readable stream body',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: { content: 'testBody', type: 'text' },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: stringToStream('{invalid json}'),
+          headers: { 'test-header': 'test-value' },
+        } as HttpResponse,
+        undefined,
+        'production',
+        undefined,
+        'parse',
+      ],
+      [
+        'should parse valid JSON from Blob body',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: { content: 'testBody', type: 'text' },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: stringToBlob('{"x":42}'),
+          headers: { 'test-header': 'test-value' },
+        } as HttpResponse,
+        { x: 42 },
+        'production',
+        undefined,
+        'parse',
+      ],
+      [
+        'should leave result undefined for invalid JSON in Blob body',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: { content: 'testBody', type: 'text' },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: stringToBlob('{invalid json}'),
+          headers: { 'test-header': 'test-value' },
+        } as HttpResponse,
+        undefined,
+        'production',
+        undefined,
+        'parse',
+      ],
+      [
+        'should leave result undefined for empty Blob body',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: { content: 'testBody', type: 'text' },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: stringToBlob(''),
+          headers: { 'test-header': 'test-value' },
+        } as HttpResponse,
+        undefined,
+        'production',
+        undefined,
+        'parse',
+      ],
+      [
+        'test with string in response body',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: {
+            content: 'testBody',
+            type: 'text',
+          },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: '{"test-string" : "value"}',
+          headers: { 'test-header': 'test-value' },
         },
-        responseType: 'text',
-        auth: { username: 'test-username', password: 'test-password' },
-      } as HttpRequest,
-      {
-        statusCode: 500,
-        body: '{"test-string" : "value"}',
-        headers: { 'test-header': 'test-value' },
-      },
-      { 'test-string': 'value' },
-      'production',
-      undefined,
-    ],
-    [
-      'test with empty string in response body',
-      {
-        method: 'GET',
-        url: 'url',
-        headers: { 'test-header': 'test-value' },
-        body: {
-          content: 'testBody',
-          type: 'text',
+        { 'test-string': 'value' },
+        'production',
+        undefined,
+        'parse',
+      ],
+      [
+        'test with empty string in response body',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: {
+            content: 'testBody',
+            type: 'text',
+          },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: '',
+          headers: { 'test-header': 'test-value' },
         },
-        responseType: 'text',
-        auth: { username: 'test-username', password: 'test-password' },
-      } as HttpRequest,
-      {
-        statusCode: 500,
-        body: '',
-        headers: { 'test-header': 'test-value' },
-      },
-      undefined,
-      'production',
-      undefined,
-    ],
-    [
-      'test with incorrect json string in response body with test-environment',
-      {
-        method: 'GET',
-        url: 'url',
-        headers: { 'test-header': 'test-value' },
-        body: {
-          content: 'testBody',
-          type: 'text',
+        undefined,
+        'production',
+        undefined,
+        'parse',
+      ],
+      [
+        'test with incorrect json string in response body with test-environment',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: {
+            content: 'testBody',
+            type: 'text',
+          },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: '[1, 2, 3, 4, ]',
+          headers: { 'test-header': 'test-value' },
+        } as HttpResponse,
+        undefined,
+        'development',
+        'Unexpected error: Could not parse HTTP response body. Unexpected \']\'',
+        'parse',
+      ],
+      [
+        'test with incorrect json string in response body with production environment',
+        {
+          method: 'GET',
+          url: 'url',
+          headers: { 'test-header': 'test-value' },
+          body: {
+            content: 'testBody',
+            type: 'text',
+          },
+          responseType: 'text',
+          auth: { username: 'test-username', password: 'test-password' },
+        } as HttpRequest,
+        {
+          statusCode: 500,
+          body: 'testBody result',
+          headers: { 'test-header': 'test-value' },
         },
-        responseType: 'text',
-        auth: { username: 'test-username', password: 'test-password' },
-      } as HttpRequest,
-      {
-        statusCode: 500,
-        body: '[1, 2, 3, 4, ]',
-        headers: { 'test-header': 'test-value' },
-      } as HttpResponse,
-      undefined,
-      'development',
-      "Unexpected error: Could not parse HTTP response body as JSON. Unexpected ']'",
-    ],
-    [
-      'test with incorrect json string in response body with production environment',
-      {
-        method: 'GET',
-        url: 'url',
-        headers: { 'test-header': 'test-value' },
-        body: {
-          content: 'testBody',
-          type: 'text',
-        },
-        responseType: 'text',
-        auth: { username: 'test-username', password: 'test-password' },
-      } as HttpRequest,
-      {
-        statusCode: 500,
-        body: 'testBody result',
-        headers: { 'test-header': 'test-value' },
-      },
-      undefined,
-      'production',
-      "Unexpected error: Could not parse HTTP response body as JSON. Unexpected ']'",
-    ],
-  ])(
-    '%s',
-    (
-      _: string,
-      request: HttpRequest,
-      response: HttpResponse,
-      expectedResult: unknown,
-      node_env: string,
-      errorMessage?: string
-    ) => {
-      process.env.NODE_ENV = node_env;
-      const apiError = new ApiError(
-        { request, response },
-        'Internal Server Error'
-      );
-      if (errorMessage !== undefined) {
-        expect(deprecationSpy).toHaveBeenCalledWith(errorMessage);
+        undefined,
+        'production',
+        'Unexpected error: Could not parse HTTP response body. Unexpected \']\'',
+        'parse',
+      ],
+    ])(
+      '%s',
+      async (
+        _: string,
+        request: HttpRequest,
+        response: HttpResponse,
+        expectedResult: unknown,
+        node_env: string,
+        errorMessage?: string,
+        testType?: string
+      ) => {
+        process.env.NODE_ENV = node_env;
+        const apiError = new ApiError(
+          { request, response },
+          'Internal Server Error'
+        );
+
+        if (testType === 'constructor') {
+          expect(apiError.request).toBe(request);
+          expect(apiError.statusCode).toBe(response.statusCode);
+          expect(apiError.headers).toEqual(response.headers);
+          expect(apiError.body).toBe(response.body);
+          expect(apiError.message).toBe('Internal Server Error');
+          expect(apiError.result).toBeUndefined();
+        } else {
+          await apiError.setResult();
+          if (errorMessage !== undefined) {
+            expect(deprecationSpy).toHaveBeenCalledWith(errorMessage);
+          }
+          expect(apiError.result).toEqual(expectedResult);
+        }
       }
-      expect(apiError.result).toEqual(expectedResult);
-    }
-  );
+    );
+  });
 });

--- a/packages/core/test/errors/apiError.test.ts
+++ b/packages/core/test/errors/apiError.test.ts
@@ -16,21 +16,29 @@ function stringToBlob(str: string, type = 'application/json') {
 describe('ApiError Class', () => {
   describe('Test API Error Instance', () => {
     const deprecationSpy = jest.spyOn(console, 'warn');
+
+    const mockHttpRequest = {
+      method: 'GET',
+      url: 'url',
+      headers: { 'test-header': 'test-value' },
+      body: { content: 'testBody', type: 'text' },
+      responseType: 'text',
+    } as HttpRequest;
+
+    const mockStatusCode = 500;
+
+    const baseResponse = {
+      statusCode: mockStatusCode,
+      headers: { 'test-header': 'test-value' },
+    };
+
     test.each([
       [
         'should set properties correctly in constructor',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: { content: 'testBody', type: 'text' },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: '',
-          headers: { 'test-header': 'test-value' },
         } as HttpResponse,
         undefined,
         'production',
@@ -39,18 +47,10 @@ describe('ApiError Class', () => {
       ],
       [
         'should parse valid JSON string body',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: { content: 'testBody', type: 'text' },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: '{"foo": "bar"}',
-          headers: { 'test-header': 'test-value' },
         } as HttpResponse,
         { foo: 'bar' },
         'production',
@@ -59,18 +59,10 @@ describe('ApiError Class', () => {
       ],
       [
         'should leave result undefined for empty string body',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: { content: 'testBody', type: 'text' },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: '',
-          headers: { 'test-header': 'test-value' },
         } as HttpResponse,
         undefined,
         'production',
@@ -79,18 +71,10 @@ describe('ApiError Class', () => {
       ],
       [
         'should parse valid JSON from Readable stream body',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: { content: 'testBody', type: 'text' },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: stringToStream('{"a":1}'),
-          headers: { 'test-header': 'test-value' },
         } as HttpResponse,
         { a: 1 },
         'production',
@@ -99,18 +83,10 @@ describe('ApiError Class', () => {
       ],
       [
         'should leave result undefined for invalid JSON string body',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: { content: 'testBody', type: 'text' },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: '{invalid json}',
-          headers: { 'test-header': 'test-value' },
         } as HttpResponse,
         undefined,
         'production',
@@ -119,18 +95,10 @@ describe('ApiError Class', () => {
       ],
       [
         'should leave result undefined for invalid JSON in Readable stream body',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: { content: 'testBody', type: 'text' },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: stringToStream('{invalid json}'),
-          headers: { 'test-header': 'test-value' },
         } as HttpResponse,
         undefined,
         'production',
@@ -139,18 +107,10 @@ describe('ApiError Class', () => {
       ],
       [
         'should parse valid JSON from Blob body',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: { content: 'testBody', type: 'text' },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: stringToBlob('{"x":42}'),
-          headers: { 'test-header': 'test-value' },
         } as HttpResponse,
         { x: 42 },
         'production',
@@ -159,18 +119,10 @@ describe('ApiError Class', () => {
       ],
       [
         'should leave result undefined for invalid JSON in Blob body',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: { content: 'testBody', type: 'text' },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: stringToBlob('{invalid json}'),
-          headers: { 'test-header': 'test-value' },
         } as HttpResponse,
         undefined,
         'production',
@@ -179,18 +131,10 @@ describe('ApiError Class', () => {
       ],
       [
         'should leave result undefined for empty Blob body',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: { content: 'testBody', type: 'text' },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: stringToBlob(''),
-          headers: { 'test-header': 'test-value' },
         } as HttpResponse,
         undefined,
         'production',
@@ -199,22 +143,11 @@ describe('ApiError Class', () => {
       ],
       [
         'test with string in response body',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: {
-            content: 'testBody',
-            type: 'text',
-          },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: '{"test-string" : "value"}',
-          headers: { 'test-header': 'test-value' },
-        },
+        } as HttpResponse,
         { 'test-string': 'value' },
         'production',
         undefined,
@@ -222,22 +155,11 @@ describe('ApiError Class', () => {
       ],
       [
         'test with empty string in response body',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: {
-            content: 'testBody',
-            type: 'text',
-          },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: '',
-          headers: { 'test-header': 'test-value' },
-        },
+        } as HttpResponse,
         undefined,
         'production',
         undefined,
@@ -245,21 +167,10 @@ describe('ApiError Class', () => {
       ],
       [
         'test with incorrect json string in response body with test-environment',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: {
-            content: 'testBody',
-            type: 'text',
-          },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: '[1, 2, 3, 4, ]',
-          headers: { 'test-header': 'test-value' },
         } as HttpResponse,
         undefined,
         'development',
@@ -268,22 +179,11 @@ describe('ApiError Class', () => {
       ],
       [
         'test with incorrect json string in response body with production environment',
+        mockHttpRequest,
         {
-          method: 'GET',
-          url: 'url',
-          headers: { 'test-header': 'test-value' },
-          body: {
-            content: 'testBody',
-            type: 'text',
-          },
-          responseType: 'text',
-          auth: { username: 'test-username', password: 'test-password' },
-        } as HttpRequest,
-        {
-          statusCode: 500,
+          ...baseResponse,
           body: 'testBody result',
-          headers: { 'test-header': 'test-value' },
-        },
+        } as HttpResponse,
         undefined,
         'production',
         'Unexpected error: Could not parse HTTP response body. Unexpected \']\'',

--- a/packages/file-wrapper/package.json
+++ b/packages/file-wrapper/package.json
@@ -20,7 +20,7 @@
     "node": ">=14.15.0 || >=16.0.0"
   },
   "scripts": {
-    "clean": "rm -rf lib es umd tsconfig.tsbuildinfo",
+    "clean": "rimraf lib es umd tsconfig.tsbuildinfo",
     "test": "jest",
     "build": "npm run clean && tsc && rollup -c --bundleConfigAsCjs && npm run annotate:es",
     "annotate:es": "babel es --out-dir es --no-babelrc --plugins annotate-pure-calls",

--- a/packages/http-headers/package.json
+++ b/packages/http-headers/package.json
@@ -20,7 +20,7 @@
     "node": ">=14.15.0 || >=16.0.0"
   },
   "scripts": {
-    "clean": "rm -rf lib es umd tsconfig.tsbuildinfo",
+    "clean": "rimraf lib es umd tsconfig.tsbuildinfo",
     "test": "jest",
     "build": "npm run clean && tsc && rollup -c --bundleConfigAsCjs && npm run annotate:es",
     "annotate:es": "babel es --out-dir es --no-babelrc --plugins annotate-pure-calls",

--- a/packages/http-query/package.json
+++ b/packages/http-query/package.json
@@ -20,7 +20,7 @@
     "node": ">=14.15.0 || >=16.0.0"
   },
   "scripts": {
-    "clean": "rm -rf lib es umd tsconfig.tsbuildinfo",
+    "clean": "rimraf lib es umd tsconfig.tsbuildinfo",
     "test": "jest",
     "build": "npm run clean && tsc && rollup -c --bundleConfigAsCjs && npm run annotate:es",
     "annotate:es": "babel es --out-dir es --no-babelrc --plugins annotate-pure-calls",

--- a/packages/oauth-adapters/package.json
+++ b/packages/oauth-adapters/package.json
@@ -20,7 +20,7 @@
     "node": ">=14.15.0 || >=16.0.0"
   },
   "scripts": {
-    "clean": "rm -rf lib es umd tsconfig.tsbuildinfo",
+    "clean": "rimraf lib es umd tsconfig.tsbuildinfo",
     "test": "jest",
     "build": "npm run clean && tsc && rollup -c --bundleConfigAsCjs && npm run annotate:es",
     "annotate:es": "babel es --out-dir es --no-babelrc --plugins annotate-pure-calls",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -20,7 +20,7 @@
     "node": ">=14.15.0 || >=16.0.0"
   },
   "scripts": {
-    "clean": "rm -rf lib es umd tsconfig.tsbuildinfo",
+    "clean": "rimraf lib es umd tsconfig.tsbuildinfo",
     "test": "jest",
     "build": "npm run clean && tsc && rollup -c --bundleConfigAsCjs && npm run annotate:es",
     "annotate:es": "babel es --out-dir es --no-babelrc --plugins annotate-pure-calls",

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -9,7 +9,7 @@
     "node": ">=14.15.0 || >=16.0.0"
   },
   "scripts": {
-    "clean": "rm -rf lib es umd tsconfig.tsbuildinfo",
+    "clean": "rimraf lib es umd tsconfig.tsbuildinfo",
     "test": "jest --passWithNoTests",
     "build": "npm run clean && tsc && rollup -c --bundleConfigAsCjs && npm run annotate:es",
     "annotate:es": "babel es --out-dir es --no-babelrc --plugins annotate-pure-calls",

--- a/packages/xml-adapter/package.json
+++ b/packages/xml-adapter/package.json
@@ -20,7 +20,7 @@
     "node": ">=14.15.0 || >=16.0.0"
   },
   "scripts": {
-    "clean": "rm -rf lib es umd tsconfig.tsbuildinfo",
+    "clean": "rimraf lib es umd tsconfig.tsbuildinfo",
     "test": "jest --passWithNoTests",
     "build": "npm run clean && tsc && rollup -c --bundleConfigAsCjs && npm run annotate:es",
     "annotate:es": "babel es --out-dir es --no-babelrc --plugins annotate-pure-calls",

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,7 @@
     "trailing-comma": [false],
     "object-literal-sort-keys": false,
     "arrow-parens": false,
-    "quotemark": [true, "single", "double"],
+    "quotemark": [true, "single"],
     "ordered-imports": [false],
     "variable-name": false,
     "object-literal-key-quotes": false,

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,7 @@
     "trailing-comma": [false],
     "object-literal-sort-keys": false,
     "arrow-parens": false,
-    "quotemark": [true, "single"],
+    "quotemark": [true, "single", "double"],
     "ordered-imports": [false],
     "variable-name": false,
     "object-literal-key-quotes": false,


### PR DESCRIPTION
This PR improves the error handling mechanism by ensuring that error.result is populated for all response body types, including string, Blob, and ReadableStream. Previously, only string response bodies were being parsed, while other types like Blob or streams left error.result empty.