### PR TITLE
chore(convert-to-stream): set public access and repository metadata

### DIFF
--- a/packages/convert-to-stream/package.json
+++ b/packages/convert-to-stream/package.json
@@ -40,5 +40,13 @@
   },
   "dependencies": {
     "tslib": "2.8.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:apimatic/apimatic-js-runtime.git",
+    "directory": "packages/convert-to-stream"
   }
 }


### PR DESCRIPTION
- Added "publishConfig.access": "public" to allow npm publishing
- Defined repository details for better npm metadata and GitHub linking