### PR TITLE
fix: api error stream body parsing to reset it afterwards

### DIFF
--- a/packages/core/test/errors/apiError.test.ts
+++ b/packages/core/test/errors/apiError.test.ts
@@ -45,13 +45,7 @@ describe('ApiError Class', () => {
         { foo: 'bar' },
         'production',
         undefined,
-      ],
-      [
-        'should leave result undefined for empty string body',
-        '',
-        undefined,
-        'production',
-        undefined,
+        false,
       ],
       [
         'should parse valid JSON from Readable stream body',
@@ -59,6 +53,23 @@ describe('ApiError Class', () => {
         { a: 1 },
         'production',
         undefined,
+        false,
+      ],
+      [
+        'should leave result undefined for empty string body',
+        '',
+        undefined,
+        'production',
+        undefined,
+        false,
+      ],
+      [
+        'should leave result undefined for empty Readable stream body',
+        convertToStream(''),
+        undefined,
+        'production',
+        undefined,
+        true,
       ],
       [
         'should leave result undefined for invalid JSON string body',
@@ -66,6 +77,7 @@ describe('ApiError Class', () => {
         undefined,
         'production',
         undefined,
+        false,
       ],
       [
         'should leave result undefined for invalid JSON in Readable stream body',
@@ -73,20 +85,15 @@ describe('ApiError Class', () => {
         undefined,
         'production',
         undefined,
+        false,
       ],
       [
-        'test with string in response body',
-        '{"test-string" : "value"}',
-        { 'test-string': 'value' },
-        'production',
-        undefined,
-      ],
-      [
-        'test with empty string in response body',
-        '',
+        'test with incorrect json string in response body with production environment',
+        'testBody result',
         undefined,
         'production',
         undefined,
+        false,
       ],
       [
         'test with incorrect json string in response body with test-environment',
@@ -94,13 +101,7 @@ describe('ApiError Class', () => {
         undefined,
         'development',
         `Unexpected error: Could not parse HTTP response body. Unexpected ']'`,
-      ],
-      [
-        'test with incorrect json string in response body with production environment',
-        'testBody result',
-        undefined,
-        'production',
-        `Unexpected error: Could not parse HTTP response body. Unexpected ']'`,
+        false,
       ],
     ])(
       '%s',
@@ -109,7 +110,8 @@ describe('ApiError Class', () => {
         body: string | NodeJS.ReadableStream | Blob,
         expectedResult: unknown,
         node_env?: string,
-        errorMessage?: string
+        errorMessage?: string,
+        isBodyAlreadyRead?: boolean
       ) => {
         process.env.NODE_ENV = node_env;
         const response = {
@@ -123,11 +125,28 @@ describe('ApiError Class', () => {
         );
 
         await loadResult(apiError);
-        if (errorMessage !== undefined) {
+        const isStreamRead = await isAlreadyRead(apiError.body);
+
+        expect(isStreamRead).toBe(isBodyAlreadyRead);
+        expect(apiError.result).toEqual(expectedResult);
+        if (errorMessage) {
           expect(deprecationSpy).toHaveBeenCalledWith(errorMessage);
         }
-        expect(apiError.result).toEqual(expectedResult);
       }
     );
+
+    async function isAlreadyRead(
+      input: string | Blob | NodeJS.ReadableStream
+    ): Promise<boolean> {
+      if (input instanceof Blob || typeof input === 'string') {
+        return false; // Blob and string is always readable
+      }
+
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of input) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      return chunks.length === 0;
+    }
   });
 });


### PR DESCRIPTION
This PR fixes the error parsing for json response handling.

Previously, we were reading the stream without resetting it. This commit fixes that behavior by converting the stringified stream back to its original type i.e., `Blob | NodeJs.ReadableStream`.

This will enable the end user to read the ApiError > body field again