### PR TITLE
fix(prerelease): don't ignore release tags merged from master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,7 @@ on:
 jobs:
   release:
     name: Publish the npm package
-    if: >-
-      ((github.ref == 'refs/heads/master' && github.event.inputs.version_type != 'prerelease (unstable or experimental changes 0.0.0-alpha.X)') ||
-      (github.ref != 'refs/heads/master' && github.event.inputs.version_type == 'prerelease (unstable or experimental changes 0.0.0-alpha.X)'))
+    if: github.ref == 'refs/heads/master' && github.event.inputs.version_type != 'prerelease (unstable or experimental changes 0.0.0-alpha.X)'
     runs-on: ubuntu-latest
     environment: Production
     steps:
@@ -42,10 +40,77 @@ jobs:
             "major (major version bump for breaking changes X.0.0)")
               echo "version=major" >> $GITHUB_ENV
               ;;
-            "prerelease (unstable or experimental changes 0.0.0-alpha.X)")
-              echo "version=prerelease" >> $GITHUB_ENV
-              ;;
           esac
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0  # Ensure the full history is fetched to push changes back
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '19'
+      
+      - name: Install dependencies and build
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+
+      - name: Configure Git and create release branch for version update
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b ci-version-update
+          git push origin ci-version-update
+      
+      - name: Configure NPM registry
+        run: npm config set registry 'https://registry.npmjs.org/'
+
+      - name: Authenticate with NPM
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+      - name: Bump versions and publish packages
+        id: release
+        run: |
+          node_modules/.bin/lerna version ${{ env.version }} --yes --conventional-commits --changelog-preset conventionalcommits --create-release github --message 'chore(release): update version and publish package(s)'
+          node_modules/.bin/lerna publish from-package --yes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push the version change
+        if: steps.release.conclusion == 'success'
+        uses: CasperWA/push-protected@v2
+        with:
+          token: ${{ secrets.PAT }}
+          branch: ${{ github.ref_name }}
+
+      - name: Delete the intermediate branch
+        if: steps.release.conclusion == 'success'
+        run: |
+           git branch -D ci-version-update &>/dev/null || true
+           git push origin :ci-version-update &>/dev/null || true
+
+      - name: Send slack notification
+        id: slack
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+            channel-id: 'C012YFE3D6D'
+            slack-message: "apimatic-js-runtime release has been triggered!"
+        env:
+            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  prerelease:
+    if: github.ref != 'refs/heads/master' && github.event.inputs.version_type == 'prerelease (unstable or experimental changes 0.0.0-alpha.X)'
+    name: Publish the npm package as an alpha release
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - name: Determine version type
+        id: version_type
+        run: echo "version=prerelease" >> $GITHUB_ENV
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Bump versions and publish packages
         id: release
         run: |
-          node_modules/.bin/lerna version ${{ env.version }} --yes --conventional-commits --changelog-preset conventionalcommits --create-release github --message 'chore(release): update version and publish package(s)'
+          node_modules/.bin/lerna version ${{ env.version }} --yes --include-merged-tags --conventional-commits --changelog-preset conventionalcommits --create-release github --message 'chore(release): update version and publish package(s)'
           node_modules/.bin/lerna publish from-package --yes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When lerna checks for changes in a feature branch, it doesn't take into account any release tags from the master branch that have been created since the feature branch was first made. That requires the `--include-merged-tags` option which is added here.