### PR TITLE
chore(file-wrapper): use public repository metadata

### DIFF
--- a/packages/file-wrapper/package.json
+++ b/packages/file-wrapper/package.json
@@ -62,7 +62,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:apimatic/apimatic-js-runtime.git",
+    "url": "https://github.com/apimatic/apimatic-js-runtime.git",
     "directory": "packages/file-wrapper"
   }
 }


### PR DESCRIPTION
## Summary
- replace the `@apimatic/file-wrapper` SSH repository URL with the public HTTPS GitHub URL
- keep the existing repository directory metadata unchanged

## Validation
- metadata assertion for the repository URL and directory
- npx -y yarn@1.22.22 install --frozen-lockfile --ignore-scripts --network-timeout 120000
- npx -y yarn@1.22.22 workspace @apimatic/file-wrapper test
- npx -y yarn@1.22.22 workspace @apimatic/file-wrapper build
- npm pack --workspace @apimatic/file-wrapper --dry-run --ignore-scripts --json
- git diff --check
